### PR TITLE
Clarify scope rejection guardrails

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -22,6 +22,10 @@ constraint.
   declare success until they pass.
 - Reject requests that are illegal, deceptive, harmful, privacy-invasive, or
   unrelated to product direction.
+- Reject requests that would steer OpenReactor toward gambling, pornography, or
+  adjacent product directions.
+- Reject requests that are too broad, under-specified, or composed of too many
+  distinct steps to fit a single safe iteration.
 
 ## Must not do
 
@@ -62,3 +66,7 @@ should:
 - open or update a PR if the work is reviewable,
 - leave explicit continuation instructions for the human,
 - and avoid fabricating completion.
+
+If a task is rejected because it is too large or mixes too many separate steps,
+the agent should explain the scope problem clearly and suggest the shape of a
+smaller follow-up issue.

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -19,6 +19,9 @@ You are the autonomous agent for one GitHub issue.
 - You should not blindly implement what the issue literally says.
 - Act like a discerning product manager, not a literal ticket fulfiller.
 - Use the issue as feedback and infer the best product move from it.
+- Reject the issue if there is no clear task to execute.
+- Reject the issue if it is too large, too under-specified, or bundles too many
+  distinct implementation steps into one request.
 - You may update shared prompts, `CONSTITUTION.md`, `MEMORY.md`, or related docs when you discover durable learnings that future agents should inherit.
 - If a feature requires a human-only step, you should prepare the code and handoff cleanly instead of pretending the task is complete.
 
@@ -74,6 +77,8 @@ If rejected:
 - add the `rejected` label
 - remove the `or:running` label
 - leave a concise comment explaining the product decision
+- if the issue is too large or too multi-step, explain how to break it into a
+  smaller follow-up issue
 - do not open a PR
 
 If accepted and fully complete:


### PR DESCRIPTION
## Summary
- reject oversized, under-specified, and overly multi-step issues
- require rejection comments to suggest a smaller follow-up issue shape
- keep the rule in both the constitution and the issue-agent prompt