### PR TITLE
Decompose oversized feature requests

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -25,7 +25,9 @@ constraint.
 - Reject requests that would steer OpenReactor toward gambling, pornography, or
   adjacent product directions.
 - Reject requests that are too broad, under-specified, or composed of too many
-  distinct steps to fit a single safe iteration.
+  distinct steps to fit a single safe iteration only when they are not worth
+  pursuing further. If the direction is worthwhile, decompose them into smaller
+  issues instead of discarding them.
 - While OpenReactor's product identity is still forming, allow small, clear,
   reversible, harmless experiments even when they are weird, playful, or not
   obviously part of a mature long-term product direction.
@@ -35,7 +37,8 @@ constraint.
 - Build automation that cannot be supervised yet.
 - Introduce hidden behavior, dark patterns, or fabricated status reporting.
 - Add infrastructure that is not required for the current MVP loop.
-- Depend on secrets or services that are not available in deployment.
+- Depend on secrets or services that are not available in deployment without a
+  clear human handoff path.
 - Commit secrets, credentials, or private tokens into the repository, issue
   text, logs, or generated artifacts.
 
@@ -87,6 +90,9 @@ should:
 - open or update a PR if the work is reviewable,
 - leave explicit continuation instructions for the human,
 - and avoid fabricating completion.
+
+If the direction is worthwhile, human-only setup is not by itself a reason to
+reject the work.
 
 If a task is rejected because it is too large or mixes too many separate steps,
 the agent should explain the scope problem clearly and suggest the shape of a

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -22,13 +22,17 @@ You are the autonomous agent for one GitHub issue.
 - Reject the issue if there is no clear task to execute.
 - Do not reject an issue only because it is strange or playful. While the
   product identity is still forming, small harmless experiments are allowed.
-- Reject the issue if it is too large, too under-specified, or bundles too many
-  distinct implementation steps into one request.
+- If the issue is too large or bundles too many distinct implementation steps
+  but is still a good direction, decompose it into smaller follow-up issues
+  instead of rejecting it outright.
 - If the structured issue metadata marks the request as maintainer steering,
   do not reject it solely for roadmap fit, product-direction fit, or
   constitution-fit concerns; still enforce safety and feasibility constraints.
 - You may update shared prompts, `CONSTITUTION.md`, `MEMORY.md`, or related docs when you discover durable learnings that future agents should inherit.
 - If a feature requires a human-only step, you should prepare the code and handoff cleanly instead of pretending the task is complete.
+- Do not reject a request solely because it requires human-only setup such as
+  API keys, OAuth registration, or account provisioning if the product
+  direction is otherwise sound.
 
 ## Required Files In The Run Directory
 
@@ -85,6 +89,14 @@ If rejected:
 - if the issue is too large or too multi-step, explain how to break it into a
   smaller follow-up issue
 - do not open a PR
+
+If decomposed:
+
+- create a small set of actionable follow-up issues in your structured result
+- do not implement the large request directly in the same run
+- explain the decomposition clearly in the parent issue comment
+- remove the `or:running` label
+- do not open a PR for the oversized parent issue itself
 
 If accepted and fully complete:
 

--- a/prompts/planner-agent.md
+++ b/prompts/planner-agent.md
@@ -1,0 +1,19 @@
+# OpenReactor Planner Agent
+
+You are the planning path for oversized but directionally valuable issues.
+
+Your job is not to implement the large request directly. Your job is to:
+
+- evaluate whether the request is worth pursuing
+- break it into a small set of narrower implementation issues
+- preserve useful human-handoff details when external setup is required
+
+Rules:
+
+- Decompose only when the request is too large, too broad, or too multi-step for one safe implementation issue.
+- Do not reject a request solely because it may require human setup such as API keys, OAuth app registration, or external account configuration.
+- Prefer 2 to 5 child issues unless the work is truly trivial.
+- Each child issue should be independently actionable by one implementation agent.
+- Child issues should not be written as public intake requests. Do not start their titles with `[Request]` and do not include the public request marker.
+- If a child issue requires human setup, include exact continuation instructions in that child issue body instead of discarding the direction.
+- If the parent request is not worth pursuing, reject it clearly rather than decomposing it.

--- a/prompts/triage-agent.md
+++ b/prompts/triage-agent.md
@@ -9,11 +9,12 @@ Rules:
 
 - Read `prompts/product-context.md`, `prompts/issue-agent.md`, `CONSTITUTION.md`,
   and `ROADMAP.md` before deciding.
-- Reject only when the issue is clearly out of bounds, clearly has no real task,
-  or is clearly too broad for one safe iteration.
+- Reject only when the issue is clearly out of bounds or clearly has no real task.
 - Dispatch anything plausible, ambiguous, weird-but-harmless, or potentially
   valuable.
 - Bias toward escalation while OpenReactor's identity is still forming.
+- Choose `spawn_codex_planner_agent` when the issue seems directionally good but
+  too large, too broad, or too multi-step for one safe implementation issue.
 - Choose `spawn_claude_ui_agent` for issues that are primarily about frontend
   design, layout, styling, UI polish, component presentation, or other visual
   UX work.
@@ -21,5 +22,8 @@ Rules:
   orchestration, infrastructure, APIs, and mixed full-stack work.
 - If structured issue metadata marks the request as maintainer steering, do not
   reject it solely for roadmap, product-direction, or constitution-fit reasons.
+- Do not reject a request solely because it may require human account setup,
+  API keys, OAuth configuration, or another human-only prerequisite. Dispatch it
+  if the direction is worthwhile.
 - Do not implement code, edit files, open PRs, or mutate GitHub state yourself.
 - Return only the structured JSON result requested by the reactor.

--- a/reactor/agent-result.schema.json
+++ b/reactor/agent-result.schema.json
@@ -9,7 +9,7 @@
     },
     "outcome": {
       "type": "string",
-      "enum": ["accepted", "rejected", "retry"]
+      "enum": ["accepted", "rejected", "retry", "decomposed"]
     },
     "summary": {
       "type": "string",
@@ -40,6 +40,34 @@
       },
       "required": ["required", "instructions"]
     },
+    "decomposition": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "overview": {
+          "type": "string"
+        },
+        "childIssues": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string",
+                "minLength": 8
+              },
+              "body": {
+                "type": "string",
+                "minLength": 20
+              }
+            },
+            "required": ["title", "body"]
+          }
+        }
+      },
+      "required": ["overview", "childIssues"]
+    },
     "tests": {
       "type": "array",
       "items": {
@@ -68,6 +96,7 @@
     "issueComment",
     "nextStep",
     "humanHandoff",
+    "decomposition",
     "tests"
   ]
 }

--- a/reactor/agent-tools.ts
+++ b/reactor/agent-tools.ts
@@ -1,11 +1,14 @@
-export type AgentToolName = "spawn_codex_issue_agent" | "spawn_claude_ui_agent";
+export type AgentToolName =
+  | "spawn_codex_issue_agent"
+  | "spawn_codex_planner_agent"
+  | "spawn_claude_ui_agent";
 
 export interface AgentToolDefinition {
   name: AgentToolName;
   label: string;
   description: string;
   provider: "codex" | "claude";
-  primaryUse: "general" | "ui";
+  primaryUse: "general" | "planning" | "ui";
 }
 
 export const DEFAULT_AGENT_TOOL: AgentToolName = "spawn_codex_issue_agent";
@@ -19,6 +22,14 @@ export const AGENT_TOOLS: Record<AgentToolName, AgentToolDefinition> = {
     provider: "codex",
     primaryUse: "general"
   },
+  spawn_codex_planner_agent: {
+    name: "spawn_codex_planner_agent",
+    label: "Codex Planner Agent",
+    description:
+      "Planning-focused Codex agent for oversized but worthwhile requests that should be decomposed into smaller executable issues.",
+    provider: "codex",
+    primaryUse: "planning"
+  },
   spawn_claude_ui_agent: {
     name: "spawn_claude_ui_agent",
     label: "Claude UI Agent",
@@ -30,7 +41,11 @@ export const AGENT_TOOLS: Record<AgentToolName, AgentToolDefinition> = {
 };
 
 export function isAgentToolName(value: string | null | undefined): value is AgentToolName {
-  return value === "spawn_codex_issue_agent" || value === "spawn_claude_ui_agent";
+  return (
+    value === "spawn_codex_issue_agent" ||
+    value === "spawn_codex_planner_agent" ||
+    value === "spawn_claude_ui_agent"
+  );
 }
 
 export function getAgentTool(value: string | null | undefined): AgentToolDefinition {

--- a/reactor/github.ts
+++ b/reactor/github.ts
@@ -65,6 +65,21 @@ export class GitHubClient {
     );
   }
 
+  async createIssue(input: {
+    title: string;
+    body: string;
+    labels?: string[];
+  }): Promise<GitHubIssue> {
+    return this.request<GitHubIssue>(`/repos/${this.config.owner}/${this.config.repo}/issues`, {
+      method: "POST",
+      body: JSON.stringify({
+        title: input.title,
+        body: input.body,
+        labels: input.labels ?? []
+      })
+    });
+  }
+
   async ensureLabel(name: string, color: string, description: string): Promise<void> {
     const encodedName = encodeURIComponent(name);
 

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -171,7 +171,7 @@ class Reactor {
       const tool = getAgentTool(toolName);
       await this.syncIssueStatusComment(issue.number, {
         status: "in-progress",
-        phase: "implementation",
+        phase: toolName === "spawn_codex_planner_agent" ? "planning" : "implementation",
         detail:
           result.toolReason ??
           `Lightweight triage selected ${tool.label} for the next implementation attempt.`
@@ -465,6 +465,46 @@ class Reactor {
         return;
       }
 
+      if (result?.outcome === "decomposed") {
+        if (!result.decomposition?.childIssues?.length) {
+          activeRun.record.status = "retry";
+          activeRun.record.lastError = "decomposed result must include at least one child issue";
+          await writeRunRecord(paths, activeRun.record);
+        } else {
+          const createdIssues = [];
+          for (const child of result.decomposition.childIssues) {
+            const title = normalizeDecomposedIssueTitle(child.title);
+            const body = ensureParentLinkInDecomposedIssueBody(activeRun.issue, child.body);
+            const createdIssue = await this.github.createIssue({
+              title,
+              body
+            });
+            createdIssues.push(createdIssue);
+          }
+
+          await this.syncIssueStatusComment(issueNumber, {
+            status: "complete",
+            phase: "planned",
+            iteration: activeRun.record.iteration,
+            detail: `Decomposed into ${createdIssues.length} follow-up issues for execution.`
+          });
+          await this.github.createComment(
+            issueNumber,
+            [
+              result.issueComment || result.summary,
+              "",
+              result.decomposition.overview,
+              "",
+              "Created follow-up issues:",
+              ...createdIssues.map((child) => `- #${child.number} ${child.title}: ${child.html_url}`)
+            ].join("\n")
+          );
+          await this.github.removeLabel(issueNumber, this.config.runningLabel);
+          await this.github.closeIssue(issueNumber, "completed");
+          return;
+        }
+      }
+
       const nextIteration = activeRun.record.iteration;
       if (nextIteration >= this.config.maxIterationsPerIssue) {
         await this.github.removeLabel(issueNumber, this.config.runningLabel);
@@ -648,6 +688,28 @@ function hasMergeConflict(pullRequest: GitHubPullRequest): boolean {
   }
 
   return false;
+}
+
+function normalizeDecomposedIssueTitle(title: string): string {
+  const cleaned = title.trim().replace(/^\[request\]\s*/i, "");
+  if (cleaned.toLowerCase().startsWith("[task]")) {
+    return cleaned;
+  }
+
+  return `[Task] ${cleaned}`;
+}
+
+function ensureParentLinkInDecomposedIssueBody(issue: GitHubIssue, body: string): string {
+  const trimmed = body.trim();
+  if (trimmed.includes(`Parent request: #${issue.number}`) || trimmed.includes(issue.html_url)) {
+    return trimmed;
+  }
+
+  return [
+    `Parent request: #${issue.number} ${issue.html_url}`,
+    "",
+    trimmed
+  ].join("\n");
 }
 
 function parseIssueNumberFromBranch(branchPrefix: string, branchName: string): number | null {

--- a/reactor/runner.ts
+++ b/reactor/runner.ts
@@ -30,15 +30,26 @@ export interface HumanHandoff {
   instructions: string;
 }
 
+export interface DecompositionChildIssue {
+  title: string;
+  body: string;
+}
+
+export interface DecompositionPlan {
+  overview: string;
+  childIssues: DecompositionChildIssue[];
+}
+
 export interface AgentResult {
   issueNumber: number;
-  outcome: "accepted" | "rejected" | "retry";
+  outcome: "accepted" | "rejected" | "retry" | "decomposed";
   summary: string;
   branchName?: string | null;
   prUrl?: string | null;
   issueComment?: string | null;
   nextStep?: string | null;
   humanHandoff?: HumanHandoff | null;
+  decomposition?: DecompositionPlan | null;
   tests: AgentTestResult[];
 }
 
@@ -47,7 +58,7 @@ export interface RunRecord {
   issueTitle: string;
   branchName: string;
   agentTool?: AgentToolName;
-  status: "running" | "accepted" | "rejected" | "retry" | "failed";
+  status: "running" | "accepted" | "rejected" | "retry" | "failed" | "decomposed";
   iteration: number;
   createdAt: string;
   updatedAt: string;
@@ -300,6 +311,9 @@ export async function spawnIssueAgent(input: {
   githubToken: string;
 }): Promise<ActiveRun> {
   const tool = getAgentTool(input.record.agentTool);
+  if (tool.name === "spawn_codex_planner_agent") {
+    return spawnCodexPlannerAgent(input);
+  }
   if (tool.provider === "claude") {
     return spawnClaudeUiIssueAgent(input);
   }
@@ -365,6 +379,85 @@ async function spawnCodexIssueAgent(input: {
   const record: RunRecord = {
     ...input.record,
     agentTool: "spawn_codex_issue_agent",
+    status: "running",
+    iteration,
+    updatedAt: new Date().toISOString(),
+    lastHeartbeatAt: new Date().toISOString(),
+    lastError: ""
+  };
+  await writeRunRecord(paths, record);
+
+  const heartbeatTimer = setInterval(() => {
+    record.updatedAt = new Date().toISOString();
+    record.lastHeartbeatAt = record.updatedAt;
+    void writeRunRecord(paths, record);
+  }, 10_000);
+
+  return {
+    issue,
+    record,
+    process: child,
+    heartbeatTimer,
+    resultPath,
+    logPath,
+    startedAt: Date.now(),
+    parseResult: () => parseAgentResult(resultPath)
+  };
+}
+
+async function spawnCodexPlannerAgent(input: {
+  config: OrchestratorConfig;
+  issue: GitHubIssue;
+  paths: IssueRuntimePaths;
+  record: RunRecord;
+  githubToken: string;
+}): Promise<ActiveRun> {
+  const { config, issue, paths, githubToken } = input;
+  const iteration = input.record.iteration + 1;
+  const schemaPath = path.join(config.repoRoot, "reactor", "agent-result.schema.json");
+  const resultPath = path.join(paths.runDir, `iteration-${iteration}.result.json`);
+  const logPath = path.join(paths.runDir, `iteration-${iteration}.log`);
+  const promptPath = path.join(paths.runDir, `iteration-${iteration}.prompt.md`);
+  const prompt = buildAgentPrompt(config, issue, paths, iteration, "spawn_codex_planner_agent");
+
+  await fs.writeFile(promptPath, prompt, "utf8");
+
+  const args = buildCodexArgs({
+    model: config.agentModel,
+    reasoningEffort: config.agentReasoningEffort,
+    serviceTier: config.agentServiceTier,
+    fullAccess: true,
+    outputSchemaPath: schemaPath,
+    outputPath: resultPath
+  });
+
+  const child = spawn("codex", args, {
+    cwd: paths.worktreePath,
+    env: {
+      ...process.env,
+      GH_TOKEN: githubToken,
+      GITHUB_TOKEN: githubToken,
+      OPENREACTOR_REPO_OWNER: config.owner,
+      OPENREACTOR_REPO_NAME: config.repo,
+      OPENREACTOR_ISSUE_NUMBER: String(issue.number),
+      OPENREACTOR_ISSUE_URL: issue.html_url,
+      OPENREACTOR_RUN_DIR: paths.runDir,
+      OPENREACTOR_PLAN_PATH: paths.planPath,
+      OPENREACTOR_PROGRESS_PATH: paths.progressPath,
+      OPENREACTOR_TASKS_PATH: paths.tasksPath,
+      OPENREACTOR_BRANCH_NAME: paths.branchName,
+      PATH: `${path.join(paths.worktreePath, "node_modules", ".bin")}${path.delimiter}${process.env.PATH ?? ""}`
+    },
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+
+  child.stdin.end(prompt);
+
+  await attachProcessLogging(child, logPath);
+
+  const record: RunRecord = {
+    ...input.record,
+    agentTool: "spawn_codex_planner_agent",
     status: "running",
     iteration,
     updatedAt: new Date().toISOString(),
@@ -556,7 +649,11 @@ function buildAgentPrompt(
   const tool = getAgentTool(agentTool);
   const maintainerSteering = getMaintainerSteeringSignal(config, issue);
   const extraFiles =
-    agentTool === "spawn_claude_ui_agent" ? ["- prompts/ui-agent.md"] : [];
+    agentTool === "spawn_claude_ui_agent"
+      ? ["- prompts/ui-agent.md"]
+      : agentTool === "spawn_codex_planner_agent"
+        ? ["- prompts/planner-agent.md"]
+        : [];
   const toolRules =
     agentTool === "spawn_claude_ui_agent"
       ? [
@@ -564,6 +661,13 @@ function buildAgentPrompt(
           "- Use prompts/ui-agent.md as your frontend design skill equivalent while making design decisions.",
           "- Prefer tight, polished UI work over broad refactors when solving the issue."
         ]
+      : agentTool === "spawn_codex_planner_agent"
+        ? [
+            `- This issue was dispatched via ${tool.label}. Your primary job is to decide whether the request should be decomposed into multiple smaller issues instead of being implemented directly.`,
+            "- Use prompts/planner-agent.md as the planning-specific rule set for this run.",
+            "- If the request is worth pursuing but too large, return `decomposed` with a structured decomposition plan instead of `rejected`.",
+            "- Do not open a PR for the oversized parent issue itself."
+          ]
       : [
           `- This issue was dispatched via ${tool.label}. Handle it as the general-purpose implementation path.`
         ];

--- a/reactor/triage-result.schema.json
+++ b/reactor/triage-result.schema.json
@@ -20,7 +20,12 @@
     },
     "toolName": {
       "type": ["string", "null"],
-      "enum": [null, "spawn_codex_issue_agent", "spawn_claude_ui_agent"]
+      "enum": [
+        null,
+        "spawn_codex_issue_agent",
+        "spawn_codex_planner_agent",
+        "spawn_claude_ui_agent"
+      ]
     },
     "toolReason": {
       "type": ["string", "null"]


### PR DESCRIPTION
## Summary
- route oversized but worthwhile requests to a Codex planner agent instead of rejecting them
- let planner runs return structured child issues that the reactor creates automatically
- stop rejecting good directions solely because they need human-only setup such as API keys or OAuth configuration

## Verification
- bun run check
