### PR TITLE
Add soft governance and engine explainer

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -28,6 +28,9 @@ constraint.
   distinct steps to fit a single safe iteration only when they are not worth
   pursuing further. If the direction is worthwhile, decompose them into smaller
   issues instead of discarding them.
+- Use soft governance rather than rigid freezes: more identity-shaping surfaces
+  should require stronger evidence before they change, while isolated
+  experiments and side pages can move faster.
 - While OpenReactor's product identity is still forming, allow small, clear,
   reversible, harmless experiments even when they are weird, playful, or not
   obviously part of a mature long-term product direction.
@@ -97,3 +100,25 @@ reject the work.
 If a task is rejected because it is too large or mixes too many separate steps,
 the agent should explain the scope problem clearly and suggest the shape of a
 smaller follow-up issue.
+
+## Sensitivity and evidence rule
+
+OpenReactor should not treat every surface as equally easy to change.
+
+- Homepage identity, brand voice, core UX framing, reactor behavior, and
+  privileged internal/admin capabilities are higher-sensitivity surfaces.
+- Shared UI patterns, navigation, and important product flows are medium
+  sensitivity.
+- Side pages, isolated experiments, and narrow reversible features are lower
+  sensitivity.
+
+Lower-sensitivity changes can move on one strong request. Higher-sensitivity
+changes should usually need stronger evidence, maintainer steering, or repeated
+supporting feedback before they are acted on.
+
+If a request looks worthwhile but should not be acted on yet, agents should
+bank it for later instead of rejecting it prematurely.
+
+Privileged admin or internal-control changes remain the one hard boundary:
+unless the request is maintainer-steered, public feedback should not directly
+change them.

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -35,9 +35,10 @@ A request should be rejected/deferred if:
 1. User submits feature request in web form.
 2. System creates GitHub issue using structured template.
 3. Request enters the reactor queue and is claimed with a GitHub label.
-4. Issue agent decides whether the request should be `accepted` or `rejected`.
-5. If accepted, the issue agent may reinterpret the request and create the best product change, then open a branch + PR.
-6. On merge to `main`, the website deploys automatically.
+4. Lightweight triage classifies surface sensitivity and evidence strength, then decides whether to `reject`, `bank`, or dispatch the request.
+5. If dispatched, an issue agent decides whether the request should be `accepted`, `rejected`, or decomposed into smaller follow-up issues.
+6. If accepted, the issue agent may reinterpret the request and create the best product change, then open a branch + PR.
+7. On merge to `main`, the website deploys automatically.
 
 ## 5) System Architecture (MVP)
 - Frontend: public website for request intake and queue visibility
@@ -77,9 +78,12 @@ Final issue outcomes are:
 
 Internal run outcomes may also include:
 - `retry`
+- `decomposed`
 
 Agent behavior requirements:
 - treat the issue as product feedback, not a binding implementation spec
+- classify the sensitivity of the affected surface and the evidence strength for acting now
+- bank worthwhile ideas when the evidence is too weak for the sensitivity level instead of rejecting them prematurely
 - reject requests that are harmful, incoherent, or not worth building
 - if accepted, choose the best product change even if it differs from the literal request
 - maintain issue comments/labels, testing notes, and PR linkage as part of the run

--- a/README.md
+++ b/README.md
@@ -1,38 +1,90 @@
 # OpenReactor
 
-OpenReactor is a self-building software platform. The immediate goal is narrower:
-launch a public website where users can submit product requests, and turn those
-requests into structured GitHub issues that agents can pick up.
+OpenReactor is an agentic harness that allows software products to evolve on
+their own.
 
-## Current MVP
+The core idea is simple: the full product lifecycle can now be automated, not
+just the code-writing step. Requests can enter a system, get judged, get turned
+into real product work, move through branches and pull requests, deploy, and
+feed their learnings back into the system again.
 
-The current MVP is intentionally small:
+The main goal of OpenReactor is to become a system that anyone can implement so
+their software products can evolve fully autonomously, without requiring a
+human to manually steer every feature, fix, and deployment.
+
+## The Engine
+
+OpenReactor works by turning software development into a living loop instead of
+a sequence of one-off tasks.
+
+In that loop:
+
+1. The website accepts a request and turns it into a structured GitHub issue.
+2. An agentic reactor decides what that request actually means for the product.
+3. The system can reject it, bank it for later, break it into smaller pieces,
+   or implement it directly.
+4. If it is worth doing, the system opens real branches and pull requests and
+   carries the work forward.
+5. When changes merge, the product redeploys and the new state becomes the next
+   thing future agents build on.
+6. The system preserves memory about product direction, constraints, and
+   learnings so the loop gets smarter over time.
+
+That is the OpenReactor engine: intake, judgment, implementation, verification,
+deployment, and memory all connected into one continuous system.
+
+## Why It Matters
+
+Most current AI software workflows stop at "generate some code."
+
+OpenReactor is aimed at something much larger: a world where software products
+can continuously improve themselves end to end. Not just writing code, but
+deciding what to build, deciding what not to build, handling ambiguity,
+preparing human handoffs when needed, opening PRs, recovering from conflicts,
+deploying, and learning from the result.
+
+If that loop becomes reliable, software development changes shape. The
+bottleneck is no longer "can the model write code?" but "can the product
+govern itself well enough to evolve safely and coherently over time?"
+
+## Governance
+
+The system is intentionally not a literal ticket fulfiller.
+
+- Issues are product feedback, not binding specs.
+- Low-sensitivity experiments can move quickly.
+- High-sensitivity surfaces such as the homepage, brand voice, and engine
+  behavior need stronger evidence or maintainer steering.
+- Good ideas do not need to be implemented immediately; they can be stored in
+  the feedback bank until more support accumulates.
+- Privileged internal/admin behavior remains a hard boundary.
+
+This is the mechanism that lets the product stay fluid without letting one
+random request rewrite its identity.
+
+## Current State
+
+What is live now:
 
 - public intake page
 - structured request form
 - GitHub issue creation
 - public queue view backed by GitHub issues
+- local reactor loop for autonomous issue handling
 
-OpenReactor is now wired to prefer GitHub App authentication for direct issue
-creation. If GitHub App credentials are not present yet, the form falls back to
-a prefilled GitHub issue creation flow so the intake loop still works.
+The website/backend and the reactor are separate:
 
-Everything else in the broader product spec is deferred until this loop is live.
+- Cloudflare Pages + Functions serve the public site and request API
+- the machine-local reactor handles autonomous triage, planning, implementation,
+  PR repair, and retry logic
 
-## Local reactor
+Today, the public website deploys continuously through Cloudflare Pages, while
+the local reactor handles the autonomous issue loop on this machine.
 
-The repository now includes a machine-local orchestration loop under
-[`reactor/`](/home/ray/projects/openreactor/reactor). It is the first
-slice of the autonomous backend:
+## Running The Reactor
 
-- polls GitHub for open issues
-- claims work with the `or:running` label
-- moves issues to `or:paused` after repeated startup failures so broken tool/config states do not loop forever
-- creates a dedicated git worktree per issue
-- spawns a fresh Codex agent for that issue
-- persists per-issue run files under `.openreactor/`
-- keeps retrying the same issue until the agent returns `accepted` or `rejected`
-- verifies that accepted runs have a pushed branch, an open PR, and no failed reported checks
+The repository includes the machine-local orchestration loop under
+[`reactor/`](/home/ray/projects/openreactor/reactor).
 
 Run it on this machine with the same GitHub environment variables already used
 for the Pages site:
@@ -52,6 +104,20 @@ Safe polling verification without claiming issues:
 ```bash
 bun run reactor:dry-run
 ```
+
+The reactor currently:
+
+- claims work with `or:running`
+- pauses repeated startup failures with `or:paused`
+- banks worthwhile-but-not-yet-actionable feedback with `feedback-bank`
+- applies `sensitivity:*` and `evidence:*` labels during triage
+- creates a dedicated git worktree per issue
+- persists per-issue run files under `.openreactor/`
+- retries the same issue until it reaches a real terminal state
+
+The operational details below exist to support the engine. They are not the
+point of the project. The point is to make the product lifecycle itself
+autonomous.
 
 Useful environment variables:
 
@@ -105,11 +171,6 @@ if their open PR becomes unmergeable due to merge conflicts, and the reactor
 also sweeps all open `openreactor/issue-*` PRs each tick so conflicted follow-up
 branches get re-claimed even when the issue itself is already closed.
 
-Each new issue now goes through a cheap lightweight triage agent first. Only
-issues that triage dispatches are handed off to an implementation tool. UI-heavy
-work can be routed to a Claude UI agent, while everything else goes to the
-standard Codex issue agent.
-
 Run files under `.openreactor/runs/issue-*` include:
 
 - `plan.json` for structured decision state
@@ -137,7 +198,7 @@ systemctl --user status --no-pager openreactor-reactor.service
 journalctl --user -u openreactor-reactor.service -n 100 --no-pager
 ```
 
-## Local development
+## Local Development
 
 1. Install dependencies:
 
@@ -167,8 +228,9 @@ Set the same secrets in Cloudflare, then deploy:
 bun run deploy
 ```
 
-See [ROADMAP.md](/home/ray/projects/openreactor/ROADMAP.md) and
-[MEMORY.md](/home/ray/projects/openreactor/MEMORY.md) for current product
-constraints and implementation decisions. Deployment details live in
+See [ROADMAP.md](/home/ray/projects/openreactor/ROADMAP.md),
+[MEMORY.md](/home/ray/projects/openreactor/MEMORY.md), and
+[PRODUCT_SPEC.md](/home/ray/projects/openreactor/PRODUCT_SPEC.md) for the
+current product direction and engine rules. Deployment details live in
 [DEPLOYMENT.md](/home/ray/projects/openreactor/DEPLOYMENT.md). GitHub App
 settings are documented in [GITHUB_APP_SETUP.md](/home/ray/projects/openreactor/GITHUB_APP_SETUP.md).

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -19,6 +19,10 @@ You are the autonomous agent for one GitHub issue.
 - You should not blindly implement what the issue literally says.
 - Act like a discerning product manager, not a literal ticket fulfiller.
 - Use the issue as feedback and infer the best product move from it.
+- Respect the triaged surface sensitivity and evidence notes in the issue
+  context file. If the requested implementation drifts into a more
+  identity-shaping or privileged surface than triage justified, narrow the
+  change, hand off, or return `retry` instead of forcing it through.
 - Reject the issue if there is no clear task to execute.
 - Do not reject an issue only because it is strange or playful. While the
   product identity is still forming, small harmless experiments are allowed.

--- a/prompts/product-context.md
+++ b/prompts/product-context.md
@@ -11,6 +11,13 @@ Core rules:
 - While OpenReactor is still discovering its identity, do not reject a clear,
   harmless issue just because it is weird. Small reversible experiments can be
   useful product discovery.
+- Not every good idea must be acted on immediately. Some feedback should be
+  banked until enough evidence accumulates or the product is ready for it.
+- More identity-shaping surfaces such as the homepage, brand voice, core UX
+  framing, and reactor behavior require stronger evidence than isolated side
+  pages or experiments.
+- Privileged internal or admin behavior is a hard boundary: unless the issue is
+  maintainer-steered, public feedback should not directly change it.
 - Final user-facing issue states are only `accepted` or `rejected`.
 - OpenReactor is open source, so no secrets or private credentials may be committed into the repo, examples, logs, prompts, or issue text.
 

--- a/prompts/triage-agent.md
+++ b/prompts/triage-agent.md
@@ -3,16 +3,32 @@
 You are the lightweight gate in front of the full issue agent.
 
 Your job is not to implement anything. Your only job is to decide whether an
-issue should be rejected cheaply or dispatched to the best implementation tool.
+issue should be rejected cheaply, banked for later, or dispatched to the best
+implementation tool.
 
 Rules:
 
 - Read `prompts/product-context.md`, `prompts/issue-agent.md`, `CONSTITUTION.md`,
   and `ROADMAP.md` before deciding.
-- Reject only when the issue is clearly out of bounds or clearly has no real task.
+- Classify the request's likely surface sensitivity as `low`, `medium`, or `high`.
+- Classify the current evidence strength for acting now as `weak`, `moderate`,
+  or `strong`.
+- Use `low` sensitivity for side pages, isolated experiments, and narrow
+  reversible features.
+- Use `medium` sensitivity for shared UI patterns, navigation, and important
+  but non-defining product flows.
+- Use `high` sensitivity for homepage identity, brand voice, core UX framing,
+  reactor behavior, deployment-critical surfaces, and privileged internal/admin
+  capabilities.
+- Reject only when the issue is clearly out of bounds, clearly has no real
+  task, or is clearly unsafe.
+- Bank an issue when the direction may be worthwhile but should not be acted on
+  yet because the evidence is too weak for its likely sensitivity, the product
+  is not ready for it yet, or the feedback should accumulate first.
 - Dispatch anything plausible, ambiguous, weird-but-harmless, or potentially
-  valuable.
-- Bias toward escalation while OpenReactor's identity is still forming.
+  valuable when the evidence is strong enough for the likely sensitivity.
+- Bias toward escalation while OpenReactor's identity is still forming,
+  especially for low-sensitivity experiments.
 - Choose `spawn_codex_planner_agent` when the issue seems directionally good but
   too large, too broad, or too multi-step for one safe implementation issue.
 - Choose `spawn_claude_ui_agent` for issues that are primarily about frontend
@@ -20,8 +36,12 @@ Rules:
   UX work.
 - Choose `spawn_codex_issue_agent` for everything else, including backend,
   orchestration, infrastructure, APIs, and mixed full-stack work.
+- Treat admin or privileged internal changes as high sensitivity. Unless the
+  issue is maintainer steering, do not dispatch those directly from random
+  public feedback.
 - If structured issue metadata marks the request as maintainer steering, do not
-  reject it solely for roadmap, product-direction, or constitution-fit reasons.
+  reject or bank it solely for roadmap, product-direction, or constitution-fit
+  reasons.
 - Do not reject a request solely because it may require human account setup,
   API keys, OAuth configuration, or another human-only prerequisite. Dispatch it
   if the direction is worthwhile.

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <title>OpenReactor</title>
     <meta
       name="description"
-      content="OpenReactor turns clear product requests into public work."
+      content="OpenReactor is a self-evolving product engine: request intake, public issues, agent judgment, PRs, and automatic deployment."
     />
     <script>
       try {
@@ -70,14 +70,15 @@
       <section class="hero-grid" aria-labelledby="page-title">
         <section class="hero-copy panel">
           <div class="product-explainer-copy">
-            <p class="eyebrow">Editorial intake loop</p>
+            <p class="eyebrow">Agentic product harness</p>
             <h1 class="hero-title" id="page-title">
               Pressure builds the brief.
             </h1>
             <p class="product-explainer-summary">
-              OpenReactor turns sharp product pressure into public GitHub issues,
-              agent judgment, and visible shipping motion. This is a taste-driven
-              front door for product work, not a polite suggestion box.
+              OpenReactor is an agentic harness for software that can evolve on
+              its own. Requests enter the system, agents decide what matters,
+              accepted work ships through public PRs, and the product learns as
+              it goes.
             </p>
           </div>
 
@@ -125,29 +126,37 @@
             <div class="product-explainer-rail" aria-label="How OpenReactor works">
               <article class="product-explainer-step">
                 <p class="product-explainer-step-number">01</p>
-                <h3>Pressure enters the queue</h3>
-                <p>Your request becomes a structured public issue instead of disappearing into a form inbox.</p>
+                <h3>Intake becomes public state</h3>
+                <p>Product pressure becomes a structured public issue instead of vanishing into a private inbox.</p>
               </article>
 
               <article class="product-explainer-step">
                 <p class="product-explainer-step-number">02</p>
-                <h3>Agents judge the move</h3>
-                <p>Scope, safety, and product coherence are evaluated before anything ships.</p>
+                <h3>The engine decides</h3>
+                <p>The system can reject, bank, decompose, or implement a request depending on what is best for the product.</p>
               </article>
 
               <article class="product-explainer-step">
                 <p class="product-explainer-step-number">03</p>
-                <h3>The branch stays public</h3>
-                <p>Accepted changes turn into visible branches and PRs. Rejections stay visible too.</p>
+                <h3>Shipping stays visible</h3>
+                <p>Accepted work becomes a branch, PR, merge, deployment, and future memory for the next cycle.</p>
               </article>
             </div>
 
             <div class="product-explainer-footer">
               <p class="product-explainer-note">
-                Expect judgment, not literal execution. Strong requests explain
-                the friction and the desired shift, then leave room for the
-                best implementation.
+                This is not just code generation. OpenReactor is about automating
+                the full product lifecycle, with more scrutiny on the changes
+                that shape the product's identity.
               </p>
+              <div class="engine-explainer" aria-label="OpenReactor engine explainer">
+                <p class="engine-explainer-kicker">Engine</p>
+                <p class="engine-explainer-copy">
+                  Intake, judgment, implementation, PR repair, merge, deploy,
+                  memory. The loop is the mechanism that lets software evolve by
+                  itself.
+                </p>
+              </div>
               <a class="product-explainer-link" href="/request-guide/">
                 Read the full request guide
               </a>

--- a/public/styles.css
+++ b/public/styles.css
@@ -623,13 +623,39 @@ button {
 
 .product-explainer-footer {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 1rem 1.25rem;
   padding: 1rem 1.05rem;
   border-top: 1px solid var(--line);
   border-left: 3px solid rgba(198, 100, 63, 0.38);
   background: linear-gradient(90deg, var(--accent-surface), rgba(198, 100, 63, 0));
+}
+
+.engine-explainer {
+  flex: 1 1 16rem;
+  min-width: min(100%, 18rem);
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--card-flat-bg);
+}
+
+.engine-explainer-kicker {
+  margin-bottom: 0.35rem;
+  color: var(--accent-dark);
+  font-family: var(--ui-font);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.engine-explainer-copy {
+  color: var(--ink-soft);
+  font-size: 0.96rem;
+  line-height: 1.65;
 }
 
 .product-explainer-link {

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -26,10 +26,22 @@ import {
   writeIssueContext,
   writeRunRecord,
   type ActiveRun,
-  type RunRecord
+  type RunRecord,
+  type TriageResult
 } from "./runner";
 
 const STATUS_COMMENT_MARKER = "<!-- openreactor:status -->";
+const FEEDBACK_BANK_LABEL = "feedback-bank";
+const SENSITIVITY_LABELS = {
+  low: "sensitivity:low",
+  medium: "sensitivity:medium",
+  high: "sensitivity:high"
+} as const;
+const EVIDENCE_LABELS = {
+  weak: "evidence:weak",
+  moderate: "evidence:moderate",
+  strong: "evidence:strong"
+} as const;
 
 class Reactor {
   private readonly config: OrchestratorConfig;
@@ -82,6 +94,11 @@ class Reactor {
       "OpenReactor paused automatic handling for this issue after repeated infrastructure failures."
     );
     await this.github.ensureLabel(
+      FEEDBACK_BANK_LABEL,
+      "c2e0c6",
+      "OpenReactor banked this feedback for later consideration instead of acting on it immediately."
+    );
+    await this.github.ensureLabel(
       this.config.acceptedLabel,
       "238636",
       "OpenReactor accepted this issue and should ship or is shipping a change."
@@ -90,6 +107,36 @@ class Reactor {
       this.config.rejectedLabel,
       "cf222e",
       "OpenReactor rejected this issue as not worth implementing."
+    );
+    await this.github.ensureLabel(
+      SENSITIVITY_LABELS.low,
+      "0e8a16",
+      "This request likely affects a low-sensitivity surface such as a side page or isolated experiment."
+    );
+    await this.github.ensureLabel(
+      SENSITIVITY_LABELS.medium,
+      "fbca04",
+      "This request likely affects a medium-sensitivity surface such as navigation or shared UI patterns."
+    );
+    await this.github.ensureLabel(
+      SENSITIVITY_LABELS.high,
+      "d73a4a",
+      "This request likely affects a high-sensitivity surface such as the homepage, engine, or privileged internals."
+    );
+    await this.github.ensureLabel(
+      EVIDENCE_LABELS.weak,
+      "8b949e",
+      "Current supporting evidence for acting on this request is weak."
+    );
+    await this.github.ensureLabel(
+      EVIDENCE_LABELS.moderate,
+      "1f6feb",
+      "Current supporting evidence for acting on this request is moderate."
+    );
+    await this.github.ensureLabel(
+      EVIDENCE_LABELS.strong,
+      "238636",
+      "Current supporting evidence for acting on this request is strong."
     );
   }
 
@@ -139,7 +186,7 @@ class Reactor {
         detail:
           "Claimed by the reactor. Starting lightweight triage before dispatching the request to the best implementation agent."
       });
-      let triageDecision: AgentToolName | null = null;
+      let triageDecision: TriageResult | null = null;
       try {
         triageDecision = await this.triageIssue(issue);
       } catch (error) {
@@ -157,7 +204,7 @@ class Reactor {
     }
   }
 
-  private async triageIssue(issue: GitHubIssue): Promise<AgentToolName | null> {
+  private async triageIssue(issue: GitHubIssue): Promise<TriageResult | null> {
     const paths = issueRuntimePaths(this.config, issue.number);
     const accessToken = await this.github.getAgentAccessToken();
     const { result } = await runIssueTriage({
@@ -166,34 +213,92 @@ class Reactor {
       paths,
       githubToken: accessToken
     });
+    const maintainerSteering = Boolean(getMaintainerSteeringSignal(this.config, issue));
+    const normalizedResult = normalizeTriageResult(result, maintainerSteering);
 
-    if (result?.outcome === "reject") {
+    if (normalizedResult) {
+      await this.syncGovernanceLabels(issue.number, normalizedResult);
+    }
+
+    if (normalizedResult?.outcome === "reject") {
       await this.syncIssueStatusComment(issue.number, {
         status: "rejected",
         phase: "triage",
         detail: "Rejected during lightweight triage as not worth pursuing in the current product direction."
       });
-      await this.github.createComment(issue.number, result.issueComment || result.summary);
+      await this.github.createComment(
+        issue.number,
+        normalizedResult.issueComment || normalizedResult.summary
+      );
       await this.github.addLabels(issue.number, [this.config.rejectedLabel]);
       await this.github.removeLabel(issue.number, this.config.runningLabel);
       await this.github.closeIssue(issue.number, "not_planned");
       return null;
     }
 
-    if (result?.outcome === "dispatch") {
-      const toolName = isAgentToolName(result.toolName) ? result.toolName : DEFAULT_AGENT_TOOL;
+    if (normalizedResult?.outcome === "bank") {
+      await this.github.addLabels(issue.number, [FEEDBACK_BANK_LABEL]);
+      await this.syncIssueStatusComment(issue.number, {
+        status: "queued",
+        phase: "banked",
+        detail:
+          normalizedResult.bankReason ??
+          `Banked for later because the current evidence is ${normalizedResult.evidenceStrength} for a ${normalizedResult.sensitivity}-sensitivity change.`
+      });
+      await this.github.createComment(
+        issue.number,
+        normalizedResult.issueComment ||
+          [
+            "OpenReactor banked this feedback for later consideration instead of acting on it immediately.",
+            "",
+            `Sensitivity: ${normalizedResult.sensitivity}`,
+            `Evidence strength: ${normalizedResult.evidenceStrength}`,
+            `Evidence summary: ${normalizedResult.evidenceSummary}`,
+            normalizedResult.bankReason ? `Reason: ${normalizedResult.bankReason}` : ""
+          ].filter(Boolean).join("\n")
+      );
+      await this.github.removeLabel(issue.number, this.config.runningLabel);
+      return null;
+    }
+
+    if (normalizedResult?.outcome === "dispatch") {
+      await this.github.removeLabel(issue.number, FEEDBACK_BANK_LABEL);
+      const toolName = isAgentToolName(normalizedResult.toolName)
+        ? normalizedResult.toolName
+        : DEFAULT_AGENT_TOOL;
       const tool = getAgentTool(toolName);
       await this.syncIssueStatusComment(issue.number, {
         status: "in-progress",
         phase: toolName === "spawn_codex_planner_agent" ? "planning" : "implementation",
         detail:
-          result.toolReason ??
-          `Lightweight triage selected ${tool.label} for the next implementation attempt.`
+          [
+            normalizedResult.toolReason ??
+              `Lightweight triage selected ${tool.label} for the next implementation attempt.`,
+            `Sensitivity: ${normalizedResult.sensitivity}.`,
+            `Evidence: ${normalizedResult.evidenceStrength}.`,
+            normalizedResult.evidenceSummary
+          ].join(" ")
       });
-      return toolName;
+      return {
+        ...normalizedResult,
+        toolName
+      };
     }
 
-    return DEFAULT_AGENT_TOOL;
+    const fallbackResult: TriageResult = {
+      issueNumber: issue.number,
+      outcome: "dispatch",
+      summary: "Defaulted to dispatch because triage result was missing or incomplete.",
+      issueComment: null,
+      sensitivity: "medium",
+      evidenceStrength: "moderate",
+      evidenceSummary: "Fallback classification because the triage result was incomplete.",
+      bankReason: null,
+      toolName: DEFAULT_AGENT_TOOL,
+      toolReason: "Fallback dispatch to the default implementation tool."
+    };
+    await this.syncGovernanceLabels(issue.number, fallbackResult);
+    return fallbackResult;
   }
 
   private async reconcileStaleActiveRuns(): Promise<void> {
@@ -411,6 +516,10 @@ class Reactor {
       return false;
     }
 
+    if (labels.has(FEEDBACK_BANK_LABEL)) {
+      return false;
+    }
+
     if (labels.has(this.config.acceptedLabel) || labels.has(this.config.rejectedLabel)) {
       return false;
     }
@@ -421,16 +530,25 @@ class Reactor {
   private async startIssue(
     issue: GitHubIssue,
     existingRecord?: RunRecord,
-    selectedTool?: AgentToolName
+    selectedTriage?: TriageResult
   ): Promise<void> {
     const paths = issueRuntimePaths(this.config, issue.number);
-    const agentTool = selectedTool ?? existingRecord?.agentTool ?? DEFAULT_AGENT_TOOL;
+    const agentTool = isAgentToolName(selectedTriage?.toolName)
+      ? selectedTriage.toolName
+      : existingRecord?.agentTool ?? DEFAULT_AGENT_TOOL;
     const record = existingRecord ?? (await createInitialRunRecord(issue, paths));
     record.agentTool = agentTool;
+    record.sensitivity = selectedTriage?.sensitivity ?? record.sensitivity;
+    record.evidenceStrength = selectedTriage?.evidenceStrength ?? record.evidenceStrength;
+    record.evidenceSummary = selectedTriage?.evidenceSummary ?? record.evidenceSummary;
 
     try {
       await ensureIssueWorktree(this.config, paths);
-      await writeIssueContext(this.config, issue, paths);
+      await writeIssueContext(this.config, issue, paths, {
+        sensitivity: record.sensitivity,
+        evidenceStrength: record.evidenceStrength,
+        evidenceSummary: record.evidenceSummary
+      });
       await writeRunRecord(paths, record);
       await this.syncIssueStatusComment(issue.number, {
         status: "in-progress",
@@ -460,6 +578,24 @@ class Reactor {
         selectedTool: agentTool
       });
     }
+  }
+
+  private async syncGovernanceLabels(issueNumber: number, triage: TriageResult): Promise<void> {
+    const labelsToClear = [
+      FEEDBACK_BANK_LABEL,
+      ...Object.values(SENSITIVITY_LABELS),
+      ...Object.values(EVIDENCE_LABELS)
+    ];
+
+    for (const label of labelsToClear) {
+      await this.github.removeLabel(issueNumber, label);
+    }
+
+    await this.github.addLabels(issueNumber, [
+      SENSITIVITY_LABELS[triage.sensitivity],
+      EVIDENCE_LABELS[triage.evidenceStrength],
+      ...(triage.outcome === "bank" ? [FEEDBACK_BANK_LABEL] : [])
+    ]);
   }
 
   private async handleStartFailure(
@@ -641,7 +777,7 @@ class Reactor {
           status: "retry",
           lastResult: result,
           lastError: result ? "" : `codex exited with code ${exitCode ?? "unknown"}`
-        }, activeRun.record.agentTool ?? DEFAULT_AGENT_TOOL);
+        });
       }
     } catch (error) {
       await this.github.removeLabel(issueNumber, this.config.runningLabel);
@@ -855,6 +991,76 @@ function getLabelNames(issue: GitHubIssue): Set<string> {
   return new Set(
     issue.labels.map((label) => (label.name ?? "").trim().toLowerCase()).filter(Boolean)
   );
+}
+
+function getMaintainerSteeringSignal(
+  config: Pick<OrchestratorConfig, "owner">,
+  issue: Pick<GitHubIssue, "body">
+): { username: string } | null {
+  const username = normalizeGitHubUsername(readStructuredIssueField(issue.body, "GitHub Username"));
+  if (!username) {
+    return null;
+  }
+
+  return username.toLowerCase() === config.owner.toLowerCase() ? { username } : null;
+}
+
+function readStructuredIssueField(body: string | null | undefined, field: string): string | null {
+  if (!body) {
+    return null;
+  }
+
+  const escapedField = field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = body.match(new RegExp(`^## ${escapedField}\\s*\\n([\\s\\S]*?)(?=\\n## \\S|$)`, "m"));
+  return match?.[1]?.trim() ?? null;
+}
+
+function normalizeGitHubUsername(value: string | null): string | null {
+  const cleaned = (value ?? "")
+    .trim()
+    .replace(/^_+|_+$/g, "")
+    .replace(/^@/, "")
+    .trim();
+
+  if (!cleaned || /^not provided$/i.test(cleaned) || /^anonymous$/i.test(cleaned)) {
+    return null;
+  }
+
+  return cleaned;
+}
+
+function normalizeTriageResult(
+  result: TriageResult | null,
+  maintainerSteering: boolean
+): TriageResult | null {
+  if (!result) {
+    return null;
+  }
+
+  if (!maintainerSteering && result.outcome === "dispatch") {
+    if (result.sensitivity === "high" && result.evidenceStrength === "weak") {
+      return {
+        ...result,
+        outcome: "bank",
+        toolName: null,
+        toolReason: null,
+        summary: "Banked because a high-sensitivity change should not move on weak evidence alone.",
+        bankReason:
+          result.bankReason ||
+          "This looks like a high-sensitivity surface, and the current evidence is too weak to act on it yet without maintainer steering or more supporting feedback.",
+        issueComment:
+          result.issueComment ||
+          [
+            "OpenReactor banked this request instead of implementing it immediately.",
+            "",
+            "Reason: it appears to affect a high-sensitivity surface, but the current evidence is still weak.",
+            "If more similar feedback accumulates or the maintainer explicitly steers this direction, it can be promoted later."
+          ].join("\n")
+      };
+    }
+  }
+
+  return result;
 }
 
 function formatError(error: unknown): string {

--- a/reactor/runner.ts
+++ b/reactor/runner.ts
@@ -16,11 +16,18 @@ export interface AgentTestResult {
   status: "passed" | "failed" | "not-run";
 }
 
+export type SurfaceSensitivity = "low" | "medium" | "high";
+export type EvidenceStrength = "weak" | "moderate" | "strong";
+
 export interface TriageResult {
   issueNumber: number;
-  outcome: "reject" | "dispatch";
+  outcome: "reject" | "dispatch" | "bank";
   summary: string;
   issueComment: string | null;
+  sensitivity: SurfaceSensitivity;
+  evidenceStrength: EvidenceStrength;
+  evidenceSummary: string;
+  bankReason: string | null;
   toolName: AgentToolName | null;
   toolReason: string | null;
 }
@@ -58,6 +65,9 @@ export interface RunRecord {
   issueTitle: string;
   branchName: string;
   agentTool?: AgentToolName;
+  sensitivity?: SurfaceSensitivity;
+  evidenceStrength?: EvidenceStrength;
+  evidenceSummary?: string;
   status: "running" | "accepted" | "rejected" | "retry" | "failed" | "decomposed";
   iteration: number;
   startFailureCount?: number;
@@ -143,7 +153,12 @@ export async function writeRunRecord(paths: IssueRuntimePaths, record: RunRecord
 export async function writeIssueContext(
   config: OrchestratorConfig,
   issue: GitHubIssue,
-  paths: IssueRuntimePaths
+  paths: IssueRuntimePaths,
+  governance?: {
+    sensitivity?: SurfaceSensitivity;
+    evidenceStrength?: EvidenceStrength;
+    evidenceSummary?: string;
+  }
 ): Promise<void> {
   const labels = issue.labels.map((label) => label.name).filter(Boolean).join(", ") || "_None_";
   const maintainerSteering = getMaintainerSteeringSignal(config, issue);
@@ -156,11 +171,14 @@ export async function writeIssueContext(
     `- URL: ${issue.html_url}`,
     `- Labels: ${labels}`,
     `- Branch: ${paths.branchName}`,
+    `- Surface sensitivity: ${governance?.sensitivity ?? "unknown"}`,
+    `- Evidence strength: ${governance?.evidenceStrength ?? "unknown"}`,
     `- Maintainer steering: ${
       maintainerSteering
         ? `yes (${maintainerSteering.username} matches repo owner ${config.owner})`
         : "no"
     }`,
+    governance?.evidenceSummary ? `- Evidence summary: ${governance.evidenceSummary}` : "",
     "",
     "## Issue Body",
     "",
@@ -186,7 +204,7 @@ export async function writeIssueContext(
     "- ROADMAP.md",
     "- MEMORY.md",
     "- README.md"
-  ].join("\n");
+  ].filter(Boolean).join("\n");
 
   await fs.mkdir(paths.runDir, { recursive: true });
   await fs.writeFile(paths.contextPath, `${content}\n`, "utf8");
@@ -488,85 +506,6 @@ async function spawnCodexPlannerAgent(input: {
   };
 }
 
-async function spawnCodexPlannerAgent(input: {
-  config: OrchestratorConfig;
-  issue: GitHubIssue;
-  paths: IssueRuntimePaths;
-  record: RunRecord;
-  githubToken: string;
-}): Promise<ActiveRun> {
-  const { config, issue, paths, githubToken } = input;
-  const iteration = input.record.iteration + 1;
-  const schemaPath = path.join(config.repoRoot, "reactor", "agent-result.schema.json");
-  const resultPath = path.join(paths.runDir, `iteration-${iteration}.result.json`);
-  const logPath = path.join(paths.runDir, `iteration-${iteration}.log`);
-  const promptPath = path.join(paths.runDir, `iteration-${iteration}.prompt.md`);
-  const prompt = buildAgentPrompt(config, issue, paths, iteration, "spawn_codex_planner_agent");
-
-  await fs.writeFile(promptPath, prompt, "utf8");
-
-  const args = buildCodexArgs({
-    model: config.agentModel,
-    reasoningEffort: config.agentReasoningEffort,
-    serviceTier: config.agentServiceTier,
-    fullAccess: true,
-    outputSchemaPath: schemaPath,
-    outputPath: resultPath
-  });
-
-  const child = spawn("codex", args, {
-    cwd: paths.worktreePath,
-    env: {
-      ...process.env,
-      GH_TOKEN: githubToken,
-      GITHUB_TOKEN: githubToken,
-      OPENREACTOR_REPO_OWNER: config.owner,
-      OPENREACTOR_REPO_NAME: config.repo,
-      OPENREACTOR_ISSUE_NUMBER: String(issue.number),
-      OPENREACTOR_ISSUE_URL: issue.html_url,
-      OPENREACTOR_RUN_DIR: paths.runDir,
-      OPENREACTOR_PLAN_PATH: paths.planPath,
-      OPENREACTOR_PROGRESS_PATH: paths.progressPath,
-      OPENREACTOR_TASKS_PATH: paths.tasksPath,
-      OPENREACTOR_BRANCH_NAME: paths.branchName,
-      PATH: `${path.join(paths.worktreePath, "node_modules", ".bin")}${path.delimiter}${process.env.PATH ?? ""}`
-    },
-    stdio: ["pipe", "pipe", "pipe"]
-  });
-
-  child.stdin.end(prompt);
-
-  await attachProcessLogging(child, logPath);
-
-  const record: RunRecord = {
-    ...input.record,
-    agentTool: "spawn_codex_planner_agent",
-    status: "running",
-    iteration,
-    updatedAt: new Date().toISOString(),
-    lastHeartbeatAt: new Date().toISOString(),
-    lastError: ""
-  };
-  await writeRunRecord(paths, record);
-
-  const heartbeatTimer = setInterval(() => {
-    record.updatedAt = new Date().toISOString();
-    record.lastHeartbeatAt = record.updatedAt;
-    void writeRunRecord(paths, record);
-  }, 10_000);
-
-  return {
-    issue,
-    record,
-    process: child,
-    heartbeatTimer,
-    resultPath,
-    logPath,
-    startedAt: Date.now(),
-    parseResult: () => parseAgentResult(resultPath)
-  };
-}
-
 async function spawnClaudeUiIssueAgent(input: {
   config: OrchestratorConfig;
   issue: GitHubIssue;
@@ -831,13 +770,20 @@ function buildTriagePrompt(config: OrchestratorConfig, issue: GitHubIssue): stri
     issue.body?.trim() || "_No body provided._",
     "",
     "Your job:",
-    "- Reject only if the issue is clearly out of bounds, clearly lacks a real task, or is clearly too broad for one safe iteration.",
-    "- Dispatch anything plausible, ambiguous, weird-but-harmless, or potentially valuable to one of the available implementation tools.",
-    "- Bias toward dispatching a tool during OpenReactor's early identity-forming stage.",
+    "- Classify the likely surface sensitivity of the request as `low`, `medium`, or `high`.",
+    "- Classify the current evidence strength for making the change now as `weak`, `moderate`, or `strong`.",
+    "- Use `low` sensitivity for side pages, isolated experiments, and narrow reversible features.",
+    "- Use `medium` sensitivity for shared UI patterns, navigation, and important but non-defining flows.",
+    "- Use `high` sensitivity for homepage identity, brand voice, core UX framing, reactor behavior, deployment-critical surfaces, and privileged internal/admin capabilities.",
+    "- Reject only if the issue is clearly out of bounds, clearly lacks a real task, or is clearly unsafe.",
+    "- Bank for later when the direction seems potentially good but should not be acted on yet because evidence is weak for the sensitivity level, timing is wrong, or the request should accumulate more supporting feedback first.",
+    "- Dispatch anything plausible, ambiguous, weird-but-harmless, or potentially valuable when the evidence is strong enough for the likely sensitivity.",
+    "- Bias toward dispatching a tool during OpenReactor's early identity-forming stage, especially for low-sensitivity experiments.",
+    "- Treat admin or privileged internal changes as high sensitivity. Unless maintainer steering is explicit, do not dispatch those from random public feedback.",
     ...(maintainerSteering
       ? [
           "- This issue is maintainer steering because the structured GitHub Username matches the repo owner.",
-          "- Do not reject it solely for roadmap fit, product-direction fit, or constitution-fit concerns. Dispatch an implementation tool unless a hard safety or feasibility blocker is obvious."
+          "- Do not reject or bank it solely for roadmap fit, product-direction fit, or constitution-fit concerns. Dispatch an implementation tool unless a hard safety or feasibility blocker is obvious."
         ]
       : []),
     "- Do not perform implementation work, open PRs, or mutate files.",

--- a/reactor/triage-result.schema.json
+++ b/reactor/triage-result.schema.json
@@ -18,6 +18,21 @@
     "issueComment": {
       "type": ["string", "null"]
     },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["low", "medium", "high"]
+    },
+    "evidenceStrength": {
+      "type": "string",
+      "enum": ["weak", "moderate", "strong"]
+    },
+    "evidenceSummary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "bankReason": {
+      "type": ["string", "null"]
+    },
     "toolName": {
       "type": ["string", "null"],
       "enum": [
@@ -31,5 +46,16 @@
       "type": ["string", "null"]
     }
   },
-  "required": ["issueNumber", "outcome", "summary", "issueComment", "toolName", "toolReason"]
+  "required": [
+    "issueNumber",
+    "outcome",
+    "summary",
+    "issueComment",
+    "sensitivity",
+    "evidenceStrength",
+    "evidenceSummary",
+    "bankReason",
+    "toolName",
+    "toolReason"
+  ]
 }


### PR DESCRIPTION
## Summary\n- add soft-governance triage with sensitivity, evidence strength, and feedback banking\n- update the reactor and prompts to carry that governance state through issue execution\n- reframe the README and homepage explainer around the OpenReactor engine itself\n\n## Verification\n- bun run check\n- bun run reactor:dry-run\n