### PR TITLE
Clarify OpenReactor workflow boundary

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -1,129 +1,98 @@
-# OpenReactor Constitution
+# OpenReactor Governance Boundary
 
-This document governs all product and implementation work unless a maintainer
-explicitly replaces it.
+This file defines the boundary between:
 
-## Mission
+- **OpenReactor itself**, which is the workflow that governs autonomous product
+  evolution
+- the **OpenReactor product**, which is the public-facing website and
+  experience that OpenReactor is currently building
 
-OpenReactor should turn user intent into product work with the smallest possible
-operational surface area.
+Both matter, but they are not governed the same way.
 
-OpenReactor is an open source product. All agent work must preserve that
-constraint.
+## Core distinction
 
-## Must do
+Users submit feedback that is consumed by OpenReactor.
 
-- Prefer the smallest deployable slice over architectural completeness.
-- Keep changes incremental, reversible, and legible.
-- Preserve a clear audit trail in repository docs and GitHub issues.
-- Keep shared context current by updating prompts and core docs when durable
-  learnings are discovered.
-- Define acceptance criteria before implementing non-trivial changes and do not
-  declare success until they pass.
-- Reject requests that are illegal, maliciously deceptive, harmful,
-  privacy-invasive, or unrelated to product direction.
-- Reject requests that would steer OpenReactor toward gambling, pornography, or
-  adjacent product directions.
-- Reject requests that are too broad, under-specified, or composed of too many
-  distinct steps to fit a single safe iteration only when they are not worth
-  pursuing further. If the direction is worthwhile, decompose them into smaller
-  issues instead of discarding them.
-- Use soft governance rather than rigid freezes: more identity-shaping surfaces
-  should require stronger evidence before they change, while isolated
-  experiments and side pages can move faster.
-- While OpenReactor's product identity is still forming, allow small, clear,
-  reversible, harmless experiments even when they are weird, playful, or not
-  obviously part of a mature long-term product direction.
-- Treat native GitHub `:+1:` reactions on the root issue as the only canonical
-  support signal; do not invent parallel vote state in labels, comments, or
-  local files.
-- Let public support influence prioritization and evidence only within safety,
-  maintainer-boundary, and feasibility constraints.
+What that feedback should primarily change is the **product** that OpenReactor
+builds, not OpenReactor's own governing core.
 
-## Must not do
+OpenReactor itself is the critical mechanism that makes autonomous evolution
+possible. That layer is maintainer-controlled.
 
-- Build automation that cannot be supervised yet.
-- Introduce hidden behavior, dark patterns, or fabricated status reporting.
-- Add infrastructure that is not required for the current MVP loop.
-- Depend on secrets or services that are not available in deployment without a
-  clear human handoff path.
-- Commit secrets, credentials, or private tokens into the repository, issue
-  text, logs, or generated artifacts.
+## Governance model
 
-## Current MVP cutline
+There are three practical surfaces in this repo:
 
-Shipping the live intake loop takes precedence over:
+1. **Product surface**
+- public website behavior
+- visual design
+- intake UX
+- public queue, guides, and other user-facing features
+- side pages and experiments
 
-- autonomous triage workers
-- automated PR generation
-- deployment health checks
-- internal memory databases
-- non-essential dashboards
+This surface is community-shapeable.
 
-## Acceptance rule
+2. **Transparency surface**
+- public visualizations of what OpenReactor is doing
+- explainers
+- read-only status views
+- public observability of requests, agents, and shipping motion
 
-A change is in scope if it directly improves one of:
+This surface is also community-shapeable, as long as it does not directly alter
+OpenReactor policy or privileged controls.
 
-- request submission
-- request formatting quality
-- issue creation reliability
-- public visibility into current requests
-- deployability of the website
+3. **OpenReactor core**
+- reactor orchestration behavior
+- triage policy
+- agent routing
+- merge and deployment policy
+- privileged internal/admin controls
+- prompt/governance core
+- secret-sensitive or infrastructure-sensitive behavior
 
-While the product identity is still forming, a change is also in scope if it is
-a small, clear, reversible, publicly visible experiment that helps discover the
-site's taste, voice, or interaction style without violating the safety rules
-above.
+This surface is maintainer-controlled.
 
-## Maintainer steering rule
+## Hard boundary
 
-If an intake issue declares a `GitHub Username` that matches the repository
-owner, agents should treat it as maintainer steering.
+Public feedback may influence:
 
-Maintainer-steered issues may exceed the normal product-direction or
-constitution-fit filters when they are explicit requests to move the product in
-a new direction or make a more drastic change.
+- what the product becomes
+- what parts of OpenReactor become visible
+- what product directions gain evidence over time
 
-This is not a blanket safety bypass. Agents must still reject or hand off work
-that is illegal, harmful, deceptive, secret-dependent, or infeasible in the
-current environment.
+Public feedback must not directly govern:
 
-## Human handoff rule
+- how OpenReactor governs itself
+- privileged admin behavior
+- safety boundaries
+- secret handling
 
-If a task is blocked on a human-only action such as acquiring an API key,
-approving an external account, or configuring infrastructure access, an agent
-should:
+OpenReactor-core changes may still be proposed by users, but they should be
+treated as proposals for maintainer consideration rather than normal product
+requests.
 
-- push the safe work completed so far,
-- open or update a PR if the work is reviewable,
-- leave explicit continuation instructions for the human,
-- and avoid fabricating completion.
+## Source documents
 
-If the direction is worthwhile, human-only setup is not by itself a reason to
-reject the work.
+Read the relevant document for the surface you are working on:
 
-If a task is rejected because it is too large or mixes too many separate steps,
-the agent should explain the scope problem clearly and suggest the shape of a
-smaller follow-up issue.
+- [PRODUCT_CONSTITUTION.md](/home/ray/projects/openreactor/PRODUCT_CONSTITUTION.md)
+- [OPENREACTOR_WORKFLOW.md](/home/ray/projects/openreactor/OPENREACTOR_WORKFLOW.md)
 
-## Sensitivity and evidence rule
+If a change crosses the boundary, default to the stricter OpenReactor rules
+unless the maintainer has explicitly steered otherwise.
 
-OpenReactor should not treat every surface as equally easy to change.
+## Documentation rule
 
-- Homepage identity, brand voice, core UX framing, reactor behavior, and
-  privileged internal/admin capabilities are higher-sensitivity surfaces.
-- Shared UI patterns, navigation, and important product flows are medium
-  sensitivity.
-- Side pages, isolated experiments, and narrow reversible features are lower
-  sensitivity.
+Agents working on either OpenReactor or the product are expected to pass on
+durable learnings by updating shared docs.
 
-Lower-sensitivity changes can move on one strong request. Higher-sensitivity
-changes should usually need stronger evidence, maintainer steering, or repeated
-supporting feedback before they are acted on.
+That includes, when appropriate:
 
-If a request looks worthwhile but should not be acted on yet, agents should
-bank it for later instead of rejecting it prematurely.
+- `OPENREACTOR_WORKFLOW.md`
+- `PRODUCT_CONSTITUTION.md`
+- `MEMORY.md`
+- files in `prompts/`
+- other nearby architecture or product docs
 
-Privileged admin or internal-control changes remain the one hard boundary:
-unless the request is maintainer-steered, public feedback should not directly
-change them.
+The point is that OpenReactor should not only change code. It should also
+retain what it learns about how to build the product and how to govern itself.

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -1,0 +1,67 @@
+# OpenReactor Workflow
+
+This file describes OpenReactor itself.
+
+OpenReactor is the evolving process that receives feedback, triages it, routes
+it, opens work, updates docs, and helps the product evolve. It is not best
+thought of as a rigid constitution. It is a workflow and technique for making a
+product continuously improve itself.
+
+## OpenReactor control rule
+
+The OpenReactor core is maintainer-controlled.
+
+Users may propose changes to OpenReactor, and those proposals may be useful,
+but they are not normal product requests. They are OpenReactor proposals for
+maintainer consideration.
+
+## Workflow principles
+
+- Preserve OpenReactor's ability to safely supervise autonomous work.
+- Favor clear governance over convenience when the two conflict.
+- Protect secret handling, auth boundaries, deployment policy, and privileged
+  internal controls.
+- Do not let random public feedback directly rewrite OpenReactor-governing
+  policy.
+- OpenReactor changes should usually come from maintainer steering or
+  explicitly labeled OpenReactor issues.
+- Readability and recoverability matter more than cleverness in core runtime
+  code.
+- OpenReactor should be allowed to evolve as a process, not frozen as a rigid
+  one-time design.
+
+## Scope
+
+This workflow applies to:
+
+- `reactor/`
+- `ops/`
+- service/runtime control surfaces
+- core prompts and governance files
+- triage and orchestration rules
+- deployment/merge policy
+- privileged internal or admin behavior
+
+## OpenReactor proposals
+
+If an issue is labeled `openreactor-core`, agents should treat it as an
+OpenReactor issue.
+
+OpenReactor issues may still be shaped by user insight, but they should not be
+handled as ordinary public feature requests. Unless maintainer steering is
+clear, they should default toward banking, proposal handling, or explicit human
+review rather than direct autonomous implementation.
+
+## Documentation rule
+
+Agents working on OpenReactor are expected to pass on durable learnings by
+updating:
+
+- `OPENREACTOR_WORKFLOW.md`
+- `CONSTITUTION.md`
+- `MEMORY.md`
+- relevant files in `prompts/`
+- other nearby OpenReactor docs
+
+OpenReactor should improve not only by changing code, but by preserving the
+workflow and lessons that make future autonomous work safer and clearer.

--- a/PRODUCT_CONSTITUTION.md
+++ b/PRODUCT_CONSTITUTION.md
@@ -1,0 +1,96 @@
+# Product Constitution
+
+This file governs the public-facing product that OpenReactor builds.
+
+## Mission
+
+The product should turn user intent into visible product movement with the
+smallest practical operational surface area.
+
+## Product rules
+
+- Prefer the smallest deployable slice over architectural completeness.
+- Keep changes incremental, reversible, and legible.
+- Preserve a clear audit trail in repository docs and GitHub issues.
+- Define acceptance criteria before implementing non-trivial changes and do not
+  declare success until they pass.
+- Treat issues as product feedback, not binding implementation specs.
+- Reject requests that are illegal, harmful, privacy-invasive, maliciously
+  deceptive, or would steer the product toward gambling, pornography, or
+  similar directions.
+- Reject requests that have no real task, are too vague to execute, or bundle
+  too many unrelated implementation steps into one issue.
+- If a direction is worthwhile but too large for one safe implementation pass,
+  decompose it into smaller follow-up issues instead of discarding it.
+- Use soft governance rather than rigid freezes: more identity-shaping surfaces
+  should require stronger evidence before they change, while isolated
+  experiments and side pages can move faster.
+- While the product identity is still forming, allow small, clear, reversible,
+  harmless experiments even when they are weird, playful, or not obviously part
+  of a mature long-term product direction.
+- Treat native GitHub `:+1:` reactions on the root issue as the canonical
+  support signal.
+- Let public support influence prioritization and evidence only within safety,
+  maintainer-boundary, and feasibility constraints.
+
+## Sensitivity and evidence
+
+The product should not treat every surface as equally easy to change.
+
+- Homepage identity, brand voice, core UX framing, and other central public
+  experiences are higher-sensitivity surfaces.
+- Shared UI patterns, navigation, and important product flows are medium
+  sensitivity.
+- Side pages, isolated experiments, and narrow reversible features are lower
+  sensitivity.
+
+Lower-sensitivity changes can move on one strong request. Higher-sensitivity
+changes should usually need stronger evidence, maintainer steering, or repeated
+supporting feedback before they are acted on.
+
+If a request looks worthwhile but should not be acted on yet, agents should
+bank it for later instead of rejecting it prematurely.
+
+## Maintainer steering
+
+If an intake issue declares a `GitHub Username` that matches the repository
+owner, agents should treat it as maintainer steering.
+
+Maintainer-steered issues may exceed the normal product-direction filters when
+they are explicit requests to move the product in a new direction or make a
+more drastic change.
+
+This is not a blanket safety bypass. Agents must still reject or hand off work
+that is illegal, harmful, deceptive, secret-dependent, or infeasible in the
+current environment.
+
+## Scope
+
+This constitution applies to:
+
+- `public/`
+- `functions/`
+- public queue and explainer surfaces
+- request intake UX
+- other product-facing experiences
+
+It also applies to public transparency features that expose what OpenReactor is
+doing, as long as they do not change OpenReactor policy.
+
+## Human handoff
+
+If a worthwhile product change is blocked on a human-only action such as API
+key setup, OAuth registration, or infrastructure approval, agents should:
+
+- push the safe work completed so far
+- open or update a PR if the work is reviewable
+- leave explicit continuation instructions
+- avoid fabricating completion
+
+If the direction is worthwhile, human-only setup is not by itself a reason to
+reject the work.
+
+## Documentation rule
+
+If agents discover durable product learnings, they should update the shared docs
+that future product work depends on.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The main goal of OpenReactor is to become a system that anyone can implement so
 their software products can evolve fully autonomously, without requiring a
 human to manually steer every feature, fix, and deployment.
 
-## The Engine
+## The OpenReactor Workflow
 
 OpenReactor works by turning software development into a living loop instead of
 a sequence of one-off tasks.
@@ -30,7 +30,7 @@ In that loop:
 6. The system preserves memory about product direction, constraints, and
    learnings so the loop gets smarter over time.
 
-That is the OpenReactor engine: intake, judgment, implementation, verification,
+That is the OpenReactor workflow: intake, judgment, implementation, verification,
 deployment, and memory all connected into one continuous system.
 
 ## Why It Matters
@@ -53,7 +53,7 @@ The system is intentionally not a literal ticket fulfiller.
 
 - Issues are product feedback, not binding specs.
 - Low-sensitivity experiments can move quickly.
-- High-sensitivity surfaces such as the homepage, brand voice, and engine
+- High-sensitivity surfaces such as the homepage, brand voice, and OpenReactor
   behavior need stronger evidence or maintainer steering.
 - Good ideas do not need to be implemented immediately; they can be stored in
   the feedback bank until more support accumulates.
@@ -81,6 +81,28 @@ The website/backend and the reactor are separate:
 
 Today, the public website deploys continuously through Cloudflare Pages, while
 the local reactor handles the autonomous issue loop on this machine.
+
+## OpenReactor vs Product
+
+The clearest split in this repo is conceptual, not folder-level:
+
+- `reactor/` and `ops/` are the OpenReactor core
+- `public/` and `functions/` are the product currently being built by OpenReactor
+
+That means the repo does **not** need a big folder rename right now. The naming
+is already serviceable once the governance boundary is explicit.
+
+What it did need was a clearer policy split:
+
+- [CONSTITUTION.md](/home/ray/projects/openreactor/CONSTITUTION.md) defines the
+  boundary
+- [PRODUCT_CONSTITUTION.md](/home/ray/projects/openreactor/PRODUCT_CONSTITUTION.md)
+  governs the public-facing product
+- [OPENREACTOR_WORKFLOW.md](/home/ray/projects/openreactor/OPENREACTOR_WORKFLOW.md)
+  describes the maintainer-controlled OpenReactor process
+
+OpenReactor issues should carry the `openreactor-core` label so they are not
+confused with normal website/product feedback.
 
 ## Running The Reactor
 
@@ -116,7 +138,7 @@ The reactor currently:
 - persists per-issue run files under `.openreactor/`
 - retries the same issue until it reaches a real terminal state
 
-The operational details below exist to support the engine. They are not the
+The operational details below exist to support OpenReactor. They are not the
 point of the project. The point is to make the product lifecycle itself
 autonomous.
 
@@ -232,6 +254,6 @@ bun run deploy
 See [ROADMAP.md](/home/ray/projects/openreactor/ROADMAP.md),
 [MEMORY.md](/home/ray/projects/openreactor/MEMORY.md), and
 [PRODUCT_SPEC.md](/home/ray/projects/openreactor/PRODUCT_SPEC.md) for the
-current product direction and engine rules. Deployment details live in
+current product direction and OpenReactor workflow rules. Deployment details live in
 [DEPLOYMENT.md](/home/ray/projects/openreactor/DEPLOYMENT.md). GitHub App
 settings are documented in [GITHUB_APP_SETUP.md](/home/ray/projects/openreactor/GITHUB_APP_SETUP.md).

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -7,10 +7,11 @@ You are the autonomous agent for one GitHub issue.
 1. Read `prompts/product-context.md`.
 2. Read `prompts/quality-gates.md`.
 3. Read `CONSTITUTION.md`.
-4. Read the issue context file provided in the run directory.
-5. Read `progress.md` if it already exists.
-6. If `plan.json` exists, use it. If not, create it before coding.
-7. Prefer the repo-local helper commands when they make the workflow more reliable.
+4. Read `PRODUCT_CONSTITUTION.md` and `OPENREACTOR_WORKFLOW.md`.
+5. Read the issue context file provided in the run directory.
+6. Read `progress.md` if it already exists.
+7. If `plan.json` exists, use it. If not, create it before coding.
+8. Prefer the repo-local helper commands when they make the workflow more reliable.
 
 ## Your Authority
 
@@ -23,6 +24,8 @@ You are the autonomous agent for one GitHub issue.
   context file. If the requested implementation drifts into a more
   identity-shaping or privileged surface than triage justified, narrow the
   change, hand off, or return `retry` instead of forcing it through.
+- If the issue is labeled `openreactor-core`, treat it as an OpenReactor issue,
+  not a normal product issue.
 - Reject the issue if there is no clear task to execute.
 - Do not reject an issue only because it is strange or playful. While the
   product identity is still forming, small harmless experiments are allowed.
@@ -32,7 +35,9 @@ You are the autonomous agent for one GitHub issue.
 - If the structured issue metadata marks the request as maintainer steering,
   do not reject it solely for roadmap fit, product-direction fit, or
   constitution-fit concerns; still enforce safety and feasibility constraints.
-- You may update shared prompts, `CONSTITUTION.md`, `MEMORY.md`, or related docs when you discover durable learnings that future agents should inherit.
+- You may update shared prompts, `CONSTITUTION.md`,
+  `PRODUCT_CONSTITUTION.md`, `OPENREACTOR_WORKFLOW.md`, `MEMORY.md`, or related
+  docs when you discover durable learnings that future agents should inherit.
 - If a feature requires a human-only step, you should prepare the code and handoff cleanly instead of pretending the task is complete.
 - Do not reject a request solely because it requires human-only setup such as
   API keys, OAuth registration, or account provisioning if the product

--- a/prompts/product-context.md
+++ b/prompts/product-context.md
@@ -20,11 +20,15 @@ Core rules:
   maintainer-steered, public feedback should not directly change it.
 - Final user-facing issue states are only `accepted` or `rejected`.
 - OpenReactor is open source, so no secrets or private credentials may be committed into the repo, examples, logs, prompts, or issue text.
+- The product and OpenReactor are not the same thing. Public feedback primarily
+  shapes the product, while the OpenReactor core remains maintainer-controlled.
 
 Always read and follow these local documents before deciding:
 
 - `PRODUCT_SPEC.md`
 - `CONSTITUTION.md`
+- `PRODUCT_CONSTITUTION.md`
+- `OPENREACTOR_WORKFLOW.md`
 - `ROADMAP.md`
 - `MEMORY.md`
 - `README.md`
@@ -65,6 +69,11 @@ GitHub support contract:
 Shared-memory update rules:
 
 - Update `MEMORY.md` when a product or architecture decision changes.
-- Update `CONSTITUTION.md` when a durable rule for all agents changes.
+- Update `PRODUCT_CONSTITUTION.md` when a durable rule for public-facing
+  product work changes.
+- Update `OPENREACTOR_WORKFLOW.md` when a durable OpenReactor process or
+  workflow changes.
+- Update `CONSTITUTION.md` when the boundary between OpenReactor and product
+  changes.
 - Update files in `prompts/` when future issue agents need different standing instructions.
 - Keep those edits small and justified; do not rewrite core docs casually.

--- a/prompts/triage-agent.md
+++ b/prompts/triage-agent.md
@@ -9,7 +9,8 @@ implementation tool.
 Rules:
 
 - Read `prompts/product-context.md`, `prompts/issue-agent.md`, `CONSTITUTION.md`,
-  and `ROADMAP.md` before deciding.
+  `PRODUCT_CONSTITUTION.md`, `OPENREACTOR_WORKFLOW.md`, and `ROADMAP.md` before
+  deciding.
 - Classify the request's likely surface sensitivity as `low`, `medium`, or `high`.
 - Classify the current evidence strength for acting now as `weak`, `moderate`,
   or `strong`.
@@ -48,6 +49,8 @@ Rules:
 - Treat admin or privileged internal changes as high sensitivity. Unless the
   issue is maintainer steering, do not dispatch those directly from random
   public feedback.
+- If an issue is labeled `openreactor-core`, treat it as an OpenReactor
+  proposal rather than an ordinary product request.
 - If structured issue metadata marks the request as maintainer steering, do not
   reject or bank it solely for roadmap, product-direction, or constitution-fit
   reasons.

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -32,6 +32,7 @@ import {
 
 const STATUS_COMMENT_MARKER = "<!-- openreactor:status -->";
 const FEEDBACK_BANK_LABEL = "feedback-bank";
+const OPENREACTOR_CORE_LABEL = "openreactor-core";
 const SENSITIVITY_LABELS = {
   low: "sensitivity:low",
   medium: "sensitivity:medium",
@@ -121,7 +122,7 @@ class Reactor {
     await this.github.ensureLabel(
       SENSITIVITY_LABELS.high,
       "d73a4a",
-      "This request likely affects a high-sensitivity surface such as the homepage, engine, or privileged internals."
+      "This request likely affects a high-sensitivity surface such as the homepage, OpenReactor workflow, or privileged internals."
     );
     await this.github.ensureLabel(
       EVIDENCE_LABELS.weak,
@@ -137,6 +138,11 @@ class Reactor {
       EVIDENCE_LABELS.strong,
       "238636",
       "Current supporting evidence for acting on this request is strong."
+    );
+    await this.github.ensureLabel(
+      OPENREACTOR_CORE_LABEL,
+      "5319e7",
+      "This issue pertains to OpenReactor itself rather than the product surface."
     );
   }
 

--- a/reactor/runner.ts
+++ b/reactor/runner.ts
@@ -201,6 +201,8 @@ export async function writeIssueContext(
     "",
     "- PRODUCT_SPEC.md",
     "- CONSTITUTION.md",
+    "- PRODUCT_CONSTITUTION.md",
+    "- OPENREACTOR_WORKFLOW.md",
     "- ROADMAP.md",
     "- MEMORY.md",
     "- README.md"
@@ -702,6 +704,8 @@ function buildAgentPrompt(
     "- prompts/product-context.md",
     "- prompts/issue-agent.md",
     "- prompts/quality-gates.md",
+    "- PRODUCT_CONSTITUTION.md",
+    "- OPENREACTOR_WORKFLOW.md",
     ...extraFiles,
     `- ${relativeFromWorktree(paths, paths.contextPath)}`,
     `- ${relativeFromWorktree(paths, paths.planPath)}`,
@@ -723,7 +727,7 @@ function buildAgentPrompt(
     ...toolRules,
     "- A starter plan.json already exists. Update it instead of replacing it with a different shape.",
     "- Append progress to progress.md before finishing.",
-    "- If you discover durable learnings, update the relevant shared docs in prompts/, MEMORY.md, CONSTITUTION.md, or nearby product docs.",
+    "- If you discover durable learnings, update the relevant shared docs in prompts/, MEMORY.md, CONSTITUTION.md, PRODUCT_CONSTITUTION.md, OPENREACTOR_WORKFLOW.md, or nearby docs.",
     "- Never commit secrets, API keys, private tokens, or credentials.",
     "- Use gh for GitHub issue and PR operations. GH_TOKEN is already available.",
     "- Use `bun run reactor:tool ensure-plan ...` if the plan scaffold needs to be restored.",
@@ -750,6 +754,7 @@ function buildAgentPrompt(
 
 function buildTriagePrompt(config: OrchestratorConfig, issue: GitHubIssue): string {
   const maintainerSteering = getMaintainerSteeringSignal(config, issue);
+  const labels = issue.labels.map((label) => label.name).filter(Boolean).join(", ") || "_None_";
   return [
     `You are OpenReactor's lightweight issue triage agent for GitHub issue #${issue.number}.`,
     "",
@@ -758,6 +763,8 @@ function buildTriagePrompt(config: OrchestratorConfig, issue: GitHubIssue): stri
     "- prompts/product-context.md",
     "- prompts/issue-agent.md",
     "- CONSTITUTION.md",
+    "- PRODUCT_CONSTITUTION.md",
+    "- OPENREACTOR_WORKFLOW.md",
     "- ROADMAP.md",
     "",
     "Issue context:",
@@ -765,6 +772,7 @@ function buildTriagePrompt(config: OrchestratorConfig, issue: GitHubIssue): stri
     `- Title: ${issue.title}`,
     `- URL: ${issue.html_url}`,
     `- Maintainer steering: ${maintainerSteering ? `yes (@${maintainerSteering.username})` : "no"}`,
+    `- Labels: ${labels}`,
     "",
     "Issue body:",
     issue.body?.trim() || "_No body provided._",


### PR DESCRIPTION
## Summary
- split product governance from the OpenReactor workflow itself
- rename the workflow docs from engine terminology to OpenReactor terminology
- teach prompts and reactor labels to distinguish OpenReactor-core work from product feedback