### PR TITLE
Block auto-merge on maintainer handoffs

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -78,3 +78,10 @@
   Reason: frontend quality decays quickly when autonomous changes rely only on
   local code edits and taste drift, so the reactor needs both a shared visual
   baseline and runtime enforcement.
+
+- Decision: if a worthwhile feature is blocked on a maintainer-only prerequisite
+  such as OAuth setup or secret provisioning, OpenReactor should leave a
+  reviewable PR open with auto-merge disabled and mark it as requiring
+  maintainer action instead of merging a documented partial.
+  Reason: maintainer-blocked features need a real waiting state in the workflow,
+  not just handoff text inside an otherwise accepted PR.

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -32,6 +32,9 @@ maintainer consideration.
 - OpenReactor should supervise itself: stalled issues and repeated local
   runtime failures should be detected, classified, and either healed
   operationally or turned into concrete OpenReactor repair work.
+- When a product issue is blocked on a maintainer-only prerequisite, OpenReactor
+  should leave a reviewable PR open, disable auto-merge, and mark the issue as
+  waiting for maintainer action instead of merging a documented partial.
 
 ## Scope
 

--- a/PRODUCT_CONSTITUTION.md
+++ b/PRODUCT_CONSTITUTION.md
@@ -92,6 +92,8 @@ key setup, OAuth registration, or infrastructure approval, agents should:
 
 - push the safe work completed so far
 - open or update a PR if the work is reviewable
+- leave that PR open without auto-merge
+- mark the issue and PR as requiring maintainer action
 - leave explicit continuation instructions
 - avoid fabricating completion
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,10 @@ bun run smoke:pages -- --base-url https://openreactor.net --cleanup
 App installation token already injected into the run. That avoids using the
 server's SSH identity for remote publication. It also enables PR auto-merge by
 default; agents should pass `--no-auto-merge` when a PR must wait for manual
-review or human intervention. Accepted issues are also re-queued automatically
+review or human intervention. If a feature is blocked on a maintainer-only step
+such as OAuth setup or secret provisioning, the reactor now leaves the PR open,
+disables auto-merge, and applies `maintainer-action-required` instead of
+merging a documented partial. Accepted issues are also re-queued automatically
 if their open PR becomes unmergeable due to merge conflicts, and the reactor
 also sweeps all open `openreactor/issue-*` PRs each tick so conflicted follow-up
 branches get re-claimed even when the issue itself is already closed.

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -147,8 +147,11 @@ If blocked on a human-only step:
 
 - push the branch if the partial work is useful
 - open or update a PR if reviewable
+- use `bun run reactor:tool ensure-pr ... --no-auto-merge` for that PR
 - leave exact human continuation instructions in the issue comment, PR body, `plan.json`, and `progress.md`
+- set `humanHandoff.required` to `true` with exact continuation instructions
 - return `retry` unless the remaining work is explicitly outside the accepted scope
+- do not return `accepted` while a maintainer-only step is still required for the feature to work as intended
 - never fabricate that the feature is complete
 
 Use this to make PR creation idempotent:

--- a/prompts/quality-gates.md
+++ b/prompts/quality-gates.md
@@ -16,6 +16,7 @@ Completion standards:
 - Do not mark an issue `accepted` if checks failed.
 - Do not mark an issue `accepted` unless at least one relevant check passed.
 - If checks cannot run, explain why in `progress.md` and do not claim full completion.
+- Do not mark an issue `accepted` if a maintainer-only action is still required before the feature can work as intended.
 - Prefer clean, reviewable commits over large speculative rewrites.
 - Use as many existing safety guards as the repo offers. If lint, tests, type checks, builds, browser verification, or schema checks exist and are relevant, run them.
 - Acceptance criteria must be satisfied, not merely attempted.

--- a/reactor/github.ts
+++ b/reactor/github.ts
@@ -26,6 +26,7 @@ export interface GitHubPullRequest {
   number: number;
   html_url: string;
   state: string;
+  node_id?: string;
   merged_at?: string | null;
   title?: string;
   mergeable?: boolean | null;
@@ -235,6 +236,31 @@ export class GitHubClient {
     );
   }
 
+  async isPullRequestAutoMergeEnabled(pullRequestNumber: number): Promise<boolean> {
+    const pullRequest = await this.getPullRequestGraphNode(pullRequestNumber);
+    return Boolean(pullRequest.autoMergeRequest);
+  }
+
+  async disablePullRequestAutoMerge(pullRequestNumber: number): Promise<void> {
+    const pullRequest = await this.getPullRequestGraphNode(pullRequestNumber);
+    if (!pullRequest.autoMergeRequest) {
+      return;
+    }
+
+    await this.graphqlRequest(
+      [
+        "mutation($pullRequestId: ID!) {",
+        "  disablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId }) {",
+        "    clientMutationId",
+        "  }",
+        "}"
+      ].join("\n"),
+      {
+        pullRequestId: pullRequest.id
+      }
+    );
+  }
+
   private async request<T = unknown>(path: string, init?: RequestInit): Promise<T> {
     const headers = new Headers(init?.headers);
     headers.set("Accept", "application/vnd.github+json");
@@ -265,6 +291,43 @@ export class GitHubClient {
     }
 
     return (await response.json()) as T;
+  }
+
+  private async graphqlRequest<T = unknown>(
+    query: string,
+    variables?: Record<string, unknown>
+  ): Promise<T> {
+    const headers = new Headers();
+    headers.set("Accept", "application/vnd.github+json");
+    headers.set("User-Agent", USER_AGENT);
+    headers.set("X-GitHub-Api-Version", API_VERSION);
+    headers.set("Content-Type", "application/json");
+
+    const accessToken = await this.getAccessToken();
+    if (accessToken) {
+      headers.set("Authorization", `Bearer ${accessToken}`);
+    }
+
+    const response = await fetch(`${API_BASE}/graphql`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        query,
+        variables: variables ?? {}
+      })
+    });
+
+    const payload = (await response.json()) as {
+      data?: T;
+      errors?: Array<{ message?: string }>;
+    };
+
+    if (!response.ok || payload.errors?.length) {
+      const detail = payload.errors?.map((error) => error.message).filter(Boolean).join("; ") ?? "";
+      throw new Error(`${response.status} ${response.statusText}${detail ? `: ${detail}` : ""}`);
+    }
+
+    return payload.data as T;
   }
 
   async getAgentAccessToken(): Promise<string> {
@@ -372,6 +435,45 @@ export class GitHubClient {
     );
 
     return `${signingInput}.${toBase64Url(signature)}`;
+  }
+
+  private async getPullRequestGraphNode(pullRequestNumber: number): Promise<{
+    id: string;
+    autoMergeRequest: { enabledAt?: string | null } | null;
+  }> {
+    const data = await this.graphqlRequest<{
+      repository: {
+        pullRequest: {
+          id: string;
+          autoMergeRequest: { enabledAt?: string | null } | null;
+        } | null;
+      };
+    }>(
+      [
+        "query($owner: String!, $repo: String!, $number: Int!) {",
+        "  repository(owner: $owner, name: $repo) {",
+        "    pullRequest(number: $number) {",
+        "      id",
+        "      autoMergeRequest {",
+        "        enabledAt",
+        "      }",
+        "    }",
+        "  }",
+        "}"
+      ].join("\n"),
+      {
+        owner: this.config.owner,
+        repo: this.config.repo,
+        number: pullRequestNumber
+      }
+    );
+
+    const pullRequest = data.repository.pullRequest;
+    if (!pullRequest) {
+      throw new Error(`Unable to load pull request #${pullRequestNumber} for auto-merge inspection.`);
+    }
+
+    return pullRequest;
   }
 }
 

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -34,6 +34,7 @@ import {
 const STATUS_COMMENT_MARKER = "<!-- openreactor:status -->";
 const FEEDBACK_BANK_LABEL = "feedback-bank";
 const OPENREACTOR_CORE_LABEL = "openreactor-core";
+const MAINTAINER_ACTION_REQUIRED_LABEL = "maintainer-action-required";
 const SENSITIVITY_LABELS = {
   low: "sensitivity:low",
   medium: "sensitivity:medium",
@@ -144,6 +145,11 @@ class Reactor {
       OPENREACTOR_CORE_LABEL,
       "5319e7",
       "This issue pertains to OpenReactor itself rather than the product surface."
+    );
+    await this.github.ensureLabel(
+      MAINTAINER_ACTION_REQUIRED_LABEL,
+      "b60205",
+      "OpenReactor prepared a PR for this issue but is waiting on a maintainer-only action before it can continue."
     );
   }
 
@@ -475,6 +481,10 @@ class Reactor {
         continue;
       }
 
+      if (record.status === "waiting-maintainer") {
+        continue;
+      }
+
       if (!record.agentTool) {
         try {
           const triageDecision = await this.triageIssue(issue);
@@ -524,6 +534,10 @@ class Reactor {
     }
 
     if (labels.has(FEEDBACK_BANK_LABEL)) {
+      return false;
+    }
+
+    if (labels.has(MAINTAINER_ACTION_REQUIRED_LABEL)) {
       return false;
     }
 
@@ -674,6 +688,47 @@ class Reactor {
         activeRun,
         paths
       });
+
+      if (result?.humanHandoff?.required) {
+        const handoffValidation = await this.validateMaintainerHandoff(paths.branchName, result);
+        if (!handoffValidation.ok) {
+          activeRun.record.status = "retry";
+          activeRun.record.lastError = handoffValidation.reason;
+          await writeRunRecord(paths, activeRun.record);
+        } else {
+          activeRun.record.status = "waiting-maintainer";
+          activeRun.record.lastError = "";
+          activeRun.record.lastResult = {
+            ...result,
+            prUrl: handoffValidation.pullRequest.html_url
+          };
+          await writeRunRecord(paths, activeRun.record);
+          await this.github.disablePullRequestAutoMerge(handoffValidation.pullRequest.number);
+          await this.github.addLabels(issueNumber, [MAINTAINER_ACTION_REQUIRED_LABEL]);
+          await this.github.addLabels(handoffValidation.pullRequest.number, [
+            MAINTAINER_ACTION_REQUIRED_LABEL
+          ]);
+          await this.github.removeLabel(issueNumber, this.config.runningLabel);
+          await this.syncIssueStatusComment(issueNumber, {
+            status: "queued",
+            phase: "waiting-maintainer",
+            iteration: activeRun.record.iteration,
+            detail: `Waiting on maintainer action before PR ${handoffValidation.pullRequest.html_url} can continue.`
+          });
+          await this.github.createComment(
+            issueNumber,
+            [
+              result.issueComment || result.summary,
+              "",
+              `OpenReactor left PR ${handoffValidation.pullRequest.html_url} open and disabled auto-merge because a maintainer-only action is still required.`,
+              "",
+              "Maintainer action required:",
+              result.humanHandoff.instructions
+            ].join("\n")
+          );
+          return;
+        }
+      }
 
       if (result?.outcome === "accepted") {
         const acceptedValidation = await this.validateAcceptedResult(paths.branchName, result);
@@ -861,6 +916,41 @@ class Reactor {
     }
 
     return { ok: true, pullRequest: mergedPullRequest };
+  }
+
+  private async validateMaintainerHandoff(
+    branchName: string,
+    result: AgentResult
+  ): Promise<
+    | { ok: true; pullRequest: GitHubPullRequest }
+    | { ok: false; reason: string }
+  > {
+    const instructions = result.humanHandoff?.instructions.trim() ?? "";
+    if (!instructions) {
+      return {
+        ok: false,
+        reason: "maintainer handoff requires explicit continuation instructions"
+      };
+    }
+
+    if (!result.branchName || result.branchName !== branchName) {
+      return { ok: false, reason: `maintainer handoff must report branch ${branchName}` };
+    }
+
+    const branchExists = await ensureRemoteBranchExists(this.config.repoRoot, branchName);
+    if (!branchExists) {
+      return { ok: false, reason: `remote branch ${branchName} was not found on origin` };
+    }
+
+    const openPullRequest = await this.github.findOpenPullRequestByBranch(branchName);
+    if (!openPullRequest) {
+      return {
+        ok: false,
+        reason: `maintainer handoff requires an open pull request for branch ${branchName}`
+      };
+    }
+
+    return { ok: true, pullRequest: openPullRequest };
   }
 
   private async syncIssueStatusComment(

--- a/reactor/runner.ts
+++ b/reactor/runner.ts
@@ -68,7 +68,14 @@ export interface RunRecord {
   sensitivity?: SurfaceSensitivity;
   evidenceStrength?: EvidenceStrength;
   evidenceSummary?: string;
-  status: "running" | "accepted" | "rejected" | "retry" | "failed" | "decomposed";
+  status:
+    | "running"
+    | "accepted"
+    | "rejected"
+    | "retry"
+    | "failed"
+    | "decomposed"
+    | "waiting-maintainer";
   iteration: number;
   startFailureCount?: number;
   createdAt: string;
@@ -761,6 +768,7 @@ function buildAgentPrompt(
     "- If you are repairing an open conflicted PR, fetch origin, merge or rebase from origin/main, resolve conflicts in the current branch, rerun checks, and update the same PR instead of opening a replacement.",
     "- Never recreate or reopen a PR that is already merged. Auto-healing only applies to the still-open PR on the issue branch.",
     "- If human action is required, prepare a clean handoff with exact instructions and do not pretend the task is fully complete.",
+    "- If a maintainer-only step still blocks the feature, do not return accepted. Leave an open PR, disable auto-merge with `--no-auto-merge`, set humanHandoff.required=true, and return retry.",
     ...(maintainerSteering
       ? [
           "- This issue is maintainer steering because the structured GitHub Username matches the repo owner.",


### PR DESCRIPTION
## Summary

- turn maintainer-only prerequisites into a real blocked workflow state instead of a documented partial merge
- disable PR auto-merge when a run returns `humanHandoff.required=true`
- add the `maintainer-action-required` issue/PR label and make the reactor stop reclaiming those issues until the maintainer unblocks them
- tighten the prompts and workflow docs so OAuth / secret / account-setup features stay open as reviewable PRs instead of merging half-finished

## Checks

- `bun run check`

## Why

The current reactor treated `humanHandoff` as documentation only. That allowed PRs like the GitHub login support flow to merge even when maintainer-only OAuth or secret setup was still required. This change makes maintainer-blocked work stay visible and blocked instead of silently counting as done.
