### PR TITLE
Branch new issue worktrees from origin main

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -69,6 +69,11 @@
 - Decision: let the watchdog open maintainer-steered `openreactor-core` repair issues when it detects a concrete OpenReactor fault that blocks issue flow.
   Reason: OpenReactor should not only recover operationally. It should also be able to route concrete faults in its own workflow back through the same autonomous issue-to-PR loop, then refresh the local services after the repair merges.
 
+- Decision: branch new issue worktrees from freshly fetched `origin/main`
+  instead of the local `main` ref.
+  Reason: local `main` can lag behind remote and create avoidable merge
+  conflicts across concurrently running issue branches.
+
 - Decision: keep CSS minimal by convention rather than enforcing a hard byte budget through scripts.
   Reason: the tendency to add lots of CSS is what causes bad design. Agents should default to the fewest possible custom styles, leaning on Tailwind utilities and avoiding decorative flourishes like gradients, shadows, and backdrop blurs.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The reactor currently:
 - pauses repeated startup failures with `or:paused`
 - banks worthwhile-but-not-yet-actionable feedback with `feedback-bank`
 - applies `sensitivity:*` and `evidence:*` labels during triage
-- creates a dedicated git worktree per issue
+- creates a dedicated git worktree per issue from the latest `origin/main`
 - persists per-issue run files under `.openreactor/`
 - retries the same issue until it reaches a real terminal state
 

--- a/reactor/runner.ts
+++ b/reactor/runner.ts
@@ -287,6 +287,8 @@ export async function ensureIssueWorktree(
     return;
   }
 
+  await refreshOriginMain(config.repoRoot);
+
   const branchExists = await runCommand("git", [
     "-C",
     config.repoRoot,
@@ -316,8 +318,12 @@ export async function ensureIssueWorktree(
     "-b",
     paths.branchName,
     paths.worktreePath,
-    "main"
+    "origin/main"
   ]);
+}
+
+async function refreshOriginMain(repoRoot: string): Promise<void> {
+  await runCommand("git", ["-C", repoRoot, "fetch", "--prune", "origin", "main"]);
 }
 
 export async function ensureRemoteBranchExists(repoRoot: string, branchName: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- fetch origin/main before creating a fresh issue worktree
- branch new issue worktrees from origin/main instead of local main
- document the change in README and MEMORY

## Verification
- bun run check
