### PR TITLE
Rename Factory Pass to Autonomous Test Run

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -143,3 +143,9 @@
   Reason: iteration counts that high are a clear signal that something is wrong
   operationally, not just that the feature needs a little more time. The right
   response is to fix the workflow, not just jiggle the process.
+
+- Decision: formalize a repeatable OpenReactor canary issue as the
+  **Autonomous Test Run**.
+  Reason: OpenReactor needs a named automated test-run technique that exercises
+  the full issue-to-PR workflow end to end, so regressions are caught by a
+  real run instead of only by waiting for ordinary feature work to expose them.

--- a/OPENREACTOR_AUTONOMOUS_TEST_RUN.md
+++ b/OPENREACTOR_AUTONOMOUS_TEST_RUN.md
@@ -1,0 +1,40 @@
+# OpenReactor Autonomous Test Run
+
+The OpenReactor Autonomous Test Run is a deliberate, automated canary run for
+OpenReactor itself.
+
+Its purpose is to exercise the real issue-to-PR loop end to end using a tiny,
+safe, reviewable OpenReactor-core change.
+
+## What it checks
+
+- issue creation and trusted maintainer steering
+- issue claiming and triage
+- agent dispatch
+- branch and PR creation
+- merge readiness
+- documentation propagation back into the repo
+
+## How to trigger it
+
+```bash
+bun run openreactor:self-test
+```
+
+That command should open or reuse a maintainer-steered `openreactor-core`
+self-test issue with the title:
+
+- `[Self-Test] OpenReactor Autonomous Test Run`
+
+## How agents should treat it
+
+- keep the change minimal
+- prefer OpenReactor docs or this file over product churn
+- use the normal OpenReactor workflow, not a shortcut path
+- record what part of the workflow was exercised and what was learned
+
+## Log
+
+- 2026-03-13: Technique renamed from `Factory Pass` to `Autonomous Test Run`
+  so the name reflects that it is both a test run and an automated OpenReactor
+  workflow exercise.

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -40,6 +40,10 @@ maintainer consideration.
 - OpenReactor should supervise itself: stalled issues and repeated local
   runtime failures should be detected, classified, and either healed
   operationally or turned into concrete OpenReactor repair work.
+- OpenReactor should periodically exercise its own workflow through an
+  automated **Autonomous Test Run** so regressions in the issue-to-PR loop are
+  caught through a real canary run, not only by waiting for production feature
+  work to fail.
 - Extremely high retry counts on one issue are themselves a failure signal.
   OpenReactor should treat that as a workflow smell, not as normal progress,
   and should route it into concrete OpenReactor repair work.
@@ -95,6 +99,30 @@ machine so the product can show:
 This visibility layer should expose metadata only. It should not expose secrets,
 terminal output, or arbitrary file contents, and it should not let the website
 control the local OpenReactor services.
+
+## Autonomous Test Run
+
+OpenReactor includes a named self-test technique: the **Autonomous Test Run**.
+
+Its purpose is to run a small, deliberate OpenReactor-core issue through the
+same workflow that normal work uses:
+
+- issue creation
+- trusted maintainer steering
+- triage
+- implementation
+- PR creation
+- merge readiness
+- documentation updates
+
+The command is:
+
+```bash
+bun run openreactor:self-test
+```
+
+The Autonomous Test Run should stay minimal and safe. It is a canary for the
+workflow, not a place to smuggle in broad OpenReactor refactors.
 
 ## Documentation rule
 

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -46,6 +46,9 @@ A request should be rejected/deferred if:
 - Website backend: API/backend for intake and future product features that require stored data
 - Reactor runtime: machine-local agent orchestration loop that polls GitHub, claims issues, spawns fresh agents, and retries until resolution
 - Watchdog runtime: machine-local supervisor that monitors the reactor, stalled issues, and repeated startup failures, attempts operational self-healing, and can emit concrete OpenReactor repair issues when the workflow itself needs to be fixed
+- OpenReactor Autonomous Test Run: a deliberate automated canary issue that
+  exercises the issue-to-PR loop end to end so workflow regressions are caught
+  through a real run
 - OpenReactor status service: machine-local read-only metadata endpoint that exposes active-agent and blocker state to the website without giving the website direct control over the local runtime
 - GitHub integration: issues, labels, comments, branches, PRs, merge state
 - Persistence (current): GitHub for durable workflow state, local `.openreactor/` files for transient run state

--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ The local read-only status feed can be served with:
 bun run openreactor-status
 ```
 
+OpenReactor also has a deliberate automated canary technique for its own
+workflow:
+
+```bash
+bun run openreactor:self-test
+```
+
+That command opens an **OpenReactor Autonomous Test Run** issue. The point is
+to exercise the normal issue-to-PR loop with a tiny OpenReactor-core change so
+workflow regressions become visible before they silently accumulate.
+
 If the public website needs to reach that local feed from Cloudflare Pages, the
 repo also includes a dedicated tunnel wrapper:
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "reactor:once": "bun run reactor/index.ts --once",
     "reactor:dry-run": "bun run reactor/index.ts --once --dry-run",
     "reactor:tool": "bun run reactor/tool.ts",
+    "openreactor:self-test": "bun run reactor/self-test.ts",
     "openreactor-status": "bun run openreactor-status/index.ts",
     "openreactor-status:tunnel": "bash scripts/openreactor-status-tunnel.sh",
     "watchdog": "bash scripts/watchdog-service.sh",

--- a/reactor/config.ts
+++ b/reactor/config.ts
@@ -182,8 +182,7 @@ function parseGitHubRemote(repoRoot: string): { owner: string; repo: string } | 
 
 function loadLocalEnv(repoRoot: string): Map<string, string> {
   const values = new Map<string, string>();
-  for (const fileName of [".dev.vars", ".env.local", ".env"]) {
-    const filePath = path.join(repoRoot, fileName);
+  for (const filePath of localEnvPaths(repoRoot)) {
     if (!fs.existsSync(filePath)) {
       continue;
     }
@@ -201,7 +200,8 @@ function loadLocalEnv(repoRoot: string): Map<string, string> {
       }
 
       const key = trimmed.slice(0, separator).trim();
-      const value = trimmed.slice(separator + 1).trim().replace(/^['"]|['"]$/g, "");
+      const rawValue = trimmed.slice(separator + 1).trim().replace(/^['"]|['"]$/g, "");
+      const value = resolveLocalEnvValue(rawValue);
       if (!values.has(key)) {
         values.set(key, value);
       }
@@ -209,6 +209,33 @@ function loadLocalEnv(repoRoot: string): Map<string, string> {
   }
 
   return values;
+}
+
+function localEnvPaths(repoRoot: string): string[] {
+  const homeDirectory = process.env.HOME ?? "";
+  const paths = [".dev.vars", ".env.local", ".env"].map((fileName) =>
+    path.join(repoRoot, fileName)
+  );
+
+  if (homeDirectory) {
+    paths.push(path.join(homeDirectory, ".config", "openreactor", "reactor.env"));
+  }
+
+  return paths;
+}
+
+function resolveLocalEnvValue(value: string): string {
+  const fileReferenceMatch = value.match(/^\$\(<\s*([^)]+?)\s*\)$/);
+  if (!fileReferenceMatch) {
+    return value;
+  }
+
+  const referencedPath = clean(fileReferenceMatch[1]);
+  if (!referencedPath || !fs.existsSync(referencedPath)) {
+    return value;
+  }
+
+  return fs.readFileSync(referencedPath, "utf8").trimEnd();
 }
 
 function valueOf(name: string, localEnv: Map<string, string>): string {

--- a/reactor/github.ts
+++ b/reactor/github.ts
@@ -90,6 +90,23 @@ export class GitHubClient {
     });
   }
 
+  async updateIssue(
+    issueNumber: number,
+    input: {
+      title?: string;
+      body?: string;
+      state?: "open" | "closed";
+    }
+  ): Promise<GitHubIssue> {
+    return this.request<GitHubIssue>(
+      `/repos/${this.config.owner}/${this.config.repo}/issues/${issueNumber}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(input)
+      }
+    );
+  }
+
   async ensureLabel(name: string, color: string, description: string): Promise<void> {
     const encodedName = encodeURIComponent(name);
 

--- a/reactor/self-test.ts
+++ b/reactor/self-test.ts
@@ -1,0 +1,131 @@
+import process from "node:process";
+import { loadConfig } from "./config";
+import { GitHubClient, type GitHubIssue } from "./github";
+
+const TITLE = "[Self-Test] OpenReactor Autonomous Test Run";
+const LEGACY_TITLE = "[Self-Test] OpenReactor Factory Pass";
+const MARKER = "<!-- openreactor:autonomous-test-run -->";
+const TRACKED_FILE = "OPENREACTOR_AUTONOMOUS_TEST_RUN.md";
+
+async function main(): Promise<void> {
+  const config = loadConfig(process.cwd());
+  const github = new GitHubClient(config);
+  const existingOpenIssue = await findOpenAutonomousTestRun(github);
+
+  const body = [
+    config.featureRequestMarker,
+    MARKER,
+    "",
+    "## Summary",
+    "Run an OpenReactor Autonomous Test Run to verify the issue-to-PR loop end to end.",
+    "",
+    "## Problem",
+    "OpenReactor needs a repeatable automated canary run that exercises the real autonomous flow. This should reveal regressions in issue claiming, triage, implementation, PR creation, merge readiness, trust propagation, and documentation updates before they become invisible workflow breakages.",
+    "",
+    "## Desired Outcome",
+    "Carry out one minimal, low-risk OpenReactor Autonomous Test Run. The accepted implementation should make the smallest safe tracked-repo change needed to prove the end-to-end loop is functioning, and it should record the pass in `OPENREACTOR_AUTONOMOUS_TEST_RUN.md`.",
+    "",
+    "## Desired Scope",
+    "25 / 100 — Minimal change",
+    "",
+    "## Constraints",
+    "- Keep the change small, safe, and easy to review.",
+    `- Prefer updating OpenReactor documentation or \`${TRACKED_FILE}\` over changing product behavior.`,
+    "- Do not introduce secrets, infrastructure churn, or broad refactors.",
+    "",
+    "## Success Criteria",
+    "- OpenReactor claims and completes the issue through the normal PR flow.",
+    `- The run appends or updates a new entry in \`${TRACKED_FILE}\`.`,
+    "- The issue comment and PR explain what part of the workflow was exercised and what was learned.",
+    "",
+    "## Additional Notes",
+    "- This is a deliberate OpenReactor canary run, not a product feature request.",
+    "- Treat it as maintainer-steered OpenReactor-core work.",
+    "",
+    "## Submitted By",
+    `GitHub @${config.owner}`,
+    "",
+    "## GitHub Username",
+    `@${config.owner}`,
+    "",
+    "## Submission Identity",
+    `Authenticated GitHub session (@${config.owner})`,
+    "",
+    "## Contact",
+    "_Not provided_",
+    "",
+    "## Intake Metadata",
+    `- Submitted at: ${new Date().toISOString()}`,
+    "- Origin: local OpenReactor Autonomous Test Run"
+  ].join("\n");
+
+  if (existingOpenIssue) {
+    await github.updateIssue(existingOpenIssue.number, {
+      title: TITLE,
+      body
+    });
+    await github.addLabels(existingOpenIssue.number, [
+      "openreactor-core",
+      config.maintainerSteeredLabel,
+      config.authenticatedSubmitterLabel
+    ]);
+    console.log(
+      JSON.stringify(
+        {
+          action: "reused",
+          number: existingOpenIssue.number,
+          title: TITLE,
+          url: existingOpenIssue.html_url
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  const createdIssue = await github.createIssue({
+    title: TITLE,
+    body,
+    labels: [
+      "openreactor-core",
+      config.maintainerSteeredLabel,
+      config.authenticatedSubmitterLabel
+    ]
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        action: "created",
+        number: createdIssue.number,
+        title: createdIssue.title,
+        url: createdIssue.html_url
+      },
+      null,
+      2
+    )
+  );
+}
+
+async function findOpenAutonomousTestRun(github: GitHubClient): Promise<GitHubIssue | null> {
+  const issues = await github.listRecentlyUpdatedIssues("open");
+  return (
+    issues.find((issue) => {
+      if (issue.pull_request) {
+        return false;
+      }
+
+      return (
+        issue.title.trim() === TITLE ||
+        issue.title.trim() === LEGACY_TITLE ||
+        (issue.body ?? "").includes(MARKER)
+      );
+    }) ?? null
+  );
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- rename the OpenReactor self-test technique to Autonomous Test Run
- add a dedicated tracked doc and CLI command for the renamed workflow
- update OpenReactor docs to describe the technique consistently

## Testing
- bun run check
- bun run openreactor:self-test
