### PR TITLE
Refresh PR execution footer deterministically

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -141,6 +141,11 @@
   Reason: provider, model, reasoning effort, and duration are hard facts that
   help explain how OpenReactor is operating without relying on vague narrative
   alone.
+- Decision: refresh PR execution footers from the reactor after a run finishes
+  instead of relying only on the earlier `ensure-pr` write.
+  Reason: the implementation execution metadata is only complete after the
+  agent exits, so a reactor-owned final refresh is the deterministic way to
+  make the PR body reflect the agent that actually finished the work.
 
 - Decision: once a running issue blows past roughly eight iterations without a
   PR, the watchdog should treat it as a workflow fault and open concrete

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -57,6 +57,9 @@ maintainer consideration.
 - OpenReactor should surface hard execution facts in public workflow artifacts
   where possible, such as provider, model, reasoning effort, and runtime
   duration, instead of relying only on narrative summaries.
+- OpenReactor should refresh PR execution footers after the run finishes so
+  the final PR body deterministically reflects the implementation agent that
+  actually produced the result.
 - When a product issue is blocked on a maintainer-only prerequisite, OpenReactor
   should leave a reviewable PR open, disable auto-merge, and mark the issue as
   waiting for maintainer action instead of merging a documented partial.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ The reactor currently:
 - records and surfaces execution metadata such as provider, model, reasoning
   effort, and duration in GitHub-visible status comments and PR bodies where
   OpenReactor has that information directly
+- refreshes PR execution footers after a run completes so the final PR body
+  reflects the implementation agent that actually finished the work
 
 The watchdog currently:
 

--- a/reactor/execution-footer.ts
+++ b/reactor/execution-footer.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export const EXECUTION_FOOTER_MARKER = "<!-- openreactor:execution-footer -->";
+
+interface ExecutionSummary {
+  providerLabel?: string | null;
+  model?: string | null;
+  reasoningEffort?: string | null;
+  serviceTier?: string | null;
+  toolLabel?: string | null;
+  durationMs?: number | null;
+}
+
+interface RunRecordSummary {
+  triageExecution?: ExecutionSummary | null;
+  lastAgentExecution?: ExecutionSummary | null;
+  lastResult?: {
+    considerations?: string[] | null;
+  } | null;
+}
+
+export async function buildExecutionFooter(runDir: string): Promise<string> {
+  const runPath = path.join(runDir, "run.json");
+  let runRecord: RunRecordSummary | null = null;
+
+  try {
+    runRecord = JSON.parse(await fs.readFile(runPath, "utf8")) as RunRecordSummary;
+  } catch {
+    return "";
+  }
+
+  const lines = [EXECUTION_FOOTER_MARKER, "## OpenReactor Execution"];
+
+  if (runRecord?.triageExecution) {
+    lines.push(`- Triage: ${formatExecutionSummary(runRecord.triageExecution)}`);
+  }
+
+  if (runRecord?.lastAgentExecution) {
+    lines.push(`- Implementation: ${formatExecutionSummary(runRecord.lastAgentExecution)}`);
+  }
+
+  const considerations = (runRecord?.lastResult?.considerations ?? [])
+    .map((item: string) => item.trim())
+    .filter(Boolean)
+    .slice(0, 6);
+
+  if (considerations.length) {
+    lines.push("- Considered:");
+    lines.push(...considerations.map((item: string) => `  - ${item}`));
+  }
+
+  return lines.length > 2 ? lines.join("\n") : "";
+}
+
+export function renderBodyWithExecutionFooter(body: string, footer: string): string {
+  const normalizedBody = stripExecutionFooter(body).trimEnd();
+  if (!footer) {
+    return normalizedBody ? `${normalizedBody}\n` : "";
+  }
+
+  if (!normalizedBody) {
+    return `${footer}\n`;
+  }
+
+  return `${normalizedBody}\n\n${footer}\n`;
+}
+
+export function stripExecutionFooter(body: string): string {
+  const footerPattern = new RegExp(`\\n*${escapeRegExp(EXECUTION_FOOTER_MARKER)}[\\s\\S]*$`);
+  return body.replace(footerPattern, "");
+}
+
+function formatExecutionSummary(execution: ExecutionSummary): string {
+  const parts = [
+    [execution.providerLabel, execution.model].filter(Boolean).join(" ").trim(),
+    execution.reasoningEffort ? `reasoning ${execution.reasoningEffort}` : "",
+    execution.serviceTier ? `service tier ${execution.serviceTier}` : "",
+    execution.toolLabel ? `tool ${execution.toolLabel}` : "",
+    typeof execution.durationMs === "number" ? `duration ${formatDurationMs(execution.durationMs)}` : ""
+  ].filter(Boolean);
+
+  return parts.join(" • ");
+}
+
+function formatDurationMs(durationMs: number): string {
+  const totalSeconds = Math.max(0, Math.round(durationMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    return `${hours}h ${remainingMinutes}m`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+
+  return `${totalSeconds}s`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/reactor/github.ts
+++ b/reactor/github.ts
@@ -29,6 +29,7 @@ export interface GitHubPullRequest {
   number: number;
   html_url: string;
   state: string;
+  body?: string | null;
   node_id?: string;
   merged_at?: string | null;
   title?: string;
@@ -226,6 +227,24 @@ export class GitHubClient {
   async getPullRequest(pullRequestNumber: number): Promise<GitHubPullRequest> {
     return this.request<GitHubPullRequest>(
       `/repos/${this.config.owner}/${this.config.repo}/pulls/${pullRequestNumber}`
+    );
+  }
+
+  async updatePullRequest(
+    pullRequestNumber: number,
+    input: {
+      title?: string;
+      body?: string;
+      state?: "open" | "closed";
+      base?: string;
+    }
+  ): Promise<GitHubPullRequest> {
+    return this.request<GitHubPullRequest>(
+      `/repos/${this.config.owner}/${this.config.repo}/pulls/${pullRequestNumber}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(input)
+      }
     );
   }
 

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -13,6 +13,7 @@ import {
   type GitHubIssueComment,
   type GitHubPullRequest
 } from "./github";
+import { buildExecutionFooter, renderBodyWithExecutionFooter } from "./execution-footer";
 import {
   type AgentResult,
   type ExecutionMetadata,
@@ -909,6 +910,7 @@ class Reactor {
             prUrl: handoffValidation.pullRequest.html_url
           };
           await writeRunRecord(paths, activeRun.record);
+          await this.refreshPullRequestExecutionFooter(handoffValidation.pullRequest.number, paths);
           await this.github.disablePullRequestAutoMerge(handoffValidation.pullRequest.number);
           await this.github.addLabels(issueNumber, [MAINTAINER_ACTION_REQUIRED_LABEL]);
           await this.github.addLabels(handoffValidation.pullRequest.number, [
@@ -955,6 +957,7 @@ class Reactor {
             prUrl: acceptedValidation.pullRequest.html_url
           };
           await writeRunRecord(paths, activeRun.record);
+          await this.refreshPullRequestExecutionFooter(acceptedValidation.pullRequest.number, paths);
           await this.syncIssueStatusComment(issueNumber, {
             status: "complete",
             phase: "accepted",
@@ -1085,6 +1088,21 @@ class Reactor {
       }
       await this.updateLiveStatus();
     }
+  }
+
+  private async refreshPullRequestExecutionFooter(
+    pullRequestNumber: number,
+    paths: IssueRuntimePaths
+  ): Promise<void> {
+    const pullRequest = await this.github.getPullRequest(pullRequestNumber);
+    const currentBody = pullRequest.body ?? "";
+    const footer = await buildExecutionFooter(paths.runDir);
+    const nextBody = renderBodyWithExecutionFooter(currentBody, footer);
+    if (nextBody === currentBody) {
+      return;
+    }
+
+    await this.github.updatePullRequest(pullRequestNumber, { body: nextBody });
   }
 
   private async updateLiveStatus(): Promise<void> {

--- a/reactor/tool.ts
+++ b/reactor/tool.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { loadConfig } from "./config";
+import { buildExecutionFooter, renderBodyWithExecutionFooter } from "./execution-footer";
 
 const execFileAsync = promisify(execFile);
 
@@ -436,14 +437,8 @@ function printHelp(): void {
 
 async function preparePullRequestBody(bodyPath: string, runDir: string): Promise<string> {
   const originalBody = await fs.readFile(bodyPath, "utf8");
-  if (originalBody.includes("<!-- openreactor:execution-footer -->")) {
-    return bodyPath;
-  }
   const footer = runDir ? await buildExecutionFooter(runDir) : "";
-
-  const nextBody = footer
-    ? `${originalBody.trimEnd()}\n\n${footer}\n`
-    : originalBody;
+  const nextBody = renderBodyWithExecutionFooter(originalBody, footer);
 
   if (nextBody === originalBody) {
     return bodyPath;
@@ -452,85 +447,6 @@ async function preparePullRequestBody(bodyPath: string, runDir: string): Promise
   const outputPath = path.join(path.dirname(bodyPath), `${path.basename(bodyPath, path.extname(bodyPath))}.openreactor${path.extname(bodyPath) || ".md"}`);
   await fs.writeFile(outputPath, nextBody, "utf8");
   return outputPath;
-}
-
-async function buildExecutionFooter(runDir: string): Promise<string> {
-  const runPath = path.join(runDir, "run.json");
-  type RunRecordSummary = {
-    triageExecution?: ExecutionSummary | null;
-    lastAgentExecution?: ExecutionSummary | null;
-    lastResult?: {
-      considerations?: string[] | null;
-    } | null;
-  };
-  let runRecord: RunRecordSummary | null = null;
-
-  try {
-    runRecord = JSON.parse(await fs.readFile(runPath, "utf8")) as RunRecordSummary;
-  } catch {
-    return "";
-  }
-
-  const lines = ["<!-- openreactor:execution-footer -->", "## OpenReactor Execution"];
-
-  if (runRecord?.triageExecution) {
-    lines.push(`- Triage: ${formatExecutionSummary(runRecord.triageExecution)}`);
-  }
-
-  if (runRecord?.lastAgentExecution) {
-    lines.push(`- Implementation: ${formatExecutionSummary(runRecord.lastAgentExecution)}`);
-  }
-
-  const considerations = (runRecord?.lastResult?.considerations ?? [])
-    .map((item: string) => item.trim())
-    .filter(Boolean)
-    .slice(0, 6);
-
-  if (considerations.length) {
-    lines.push("- Considered:");
-    lines.push(...considerations.map((item: string) => `  - ${item}`));
-  }
-
-  return lines.length > 2 ? lines.join("\n") : "";
-}
-
-interface ExecutionSummary {
-  providerLabel?: string | null;
-  model?: string | null;
-  reasoningEffort?: string | null;
-  serviceTier?: string | null;
-  toolLabel?: string | null;
-  durationMs?: number | null;
-}
-
-function formatExecutionSummary(execution: ExecutionSummary): string {
-  const parts = [
-    [execution.providerLabel, execution.model].filter(Boolean).join(" ").trim(),
-    execution.reasoningEffort ? `reasoning ${execution.reasoningEffort}` : "",
-    execution.serviceTier ? `service tier ${execution.serviceTier}` : "",
-    execution.toolLabel ? `tool ${execution.toolLabel}` : "",
-    typeof execution.durationMs === "number" ? `duration ${formatDurationMs(execution.durationMs)}` : ""
-  ].filter(Boolean);
-
-  return parts.join(" • ");
-}
-
-function formatDurationMs(durationMs: number): string {
-  const totalSeconds = Math.max(0, Math.round(durationMs / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-
-  if (minutes >= 60) {
-    const hours = Math.floor(minutes / 60);
-    const remainingMinutes = minutes % 60;
-    return `${hours}h ${remainingMinutes}m`;
-  }
-
-  if (minutes > 0) {
-    return `${minutes}m ${seconds}s`;
-  }
-
-  return `${totalSeconds}s`;
 }
 
 void main();


### PR DESCRIPTION
## Summary
- make execution footer rendering idempotent and shared between the PR tool and reactor
- refresh the PR body after accepted and maintainer-handoff runs finish so implementation metadata is final
- document the deterministic footer refresh in OpenReactor docs

## Verification
- bun run check
- bun -e 'import { buildExecutionFooter } from "./reactor/execution-footer"; const footer = await buildExecutionFooter(".openreactor/runs/issue-210"); console.log(footer);'