### PR TITLE
Add planner issue dependencies

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -167,3 +167,10 @@
   `needs-refinement` label.
   Reason: deferred requests should stay visible for follow-up, but they should
   not look identical to fresh queued work.
+
+- Decision: give the planner its own higher-reasoning configuration and let it
+  create GitHub-native sub-issues plus dependency edges for decomposed work.
+  Reason: decomposition needs more careful sequencing judgment than ordinary
+  implementation, and native issue dependencies let OpenReactor avoid starting
+  blocked child tasks while still allowing independent children to run in
+  parallel.

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -60,6 +60,10 @@ maintainer consideration.
 - OpenReactor should refresh PR execution footers after the run finishes so
   the final PR body deterministically reflects the implementation agent that
   actually produced the result.
+- When OpenReactor decomposes an oversized issue, it should create GitHub-native
+  sub-issues for the child tasks and add issue dependencies only for true
+  blocking relationships, so independent child tasks can still run in
+  parallel.
 - When a product issue is blocked on a maintainer-only prerequisite, OpenReactor
   should leave a reviewable PR open, disable auto-merge, and mark the issue as
   waiting for maintainer action instead of merging a documented partial.

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -38,6 +38,7 @@ A request should be rejected/deferred if:
 4. Lightweight triage classifies surface sensitivity and evidence strength, then decides whether to `reject`, `bank`, or dispatch the request.
 5. Ongoing issue discussion can refine the request; banked, paused, or previously rejected issues may be reconsidered when later comments materially change the task or explicitly call OpenReactor back in.
 6. If dispatched, an issue agent decides whether the request should be `accepted`, `rejected`, or decomposed into smaller follow-up issues.
+7. Decomposed follow-up issues may be linked with GitHub-native dependencies when one child task truly blocks another. Independent child tasks should remain parallelizable.
 7. If accepted, the issue agent may reinterpret the request and create the best product change, then open a branch + PR.
 8. On merge to `main`, the website deploys automatically.
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ The reactor currently:
   OpenReactor has that information directly
 - refreshes PR execution footers after a run completes so the final PR body
   reflects the implementation agent that actually finished the work
+- decomposes oversized requests into GitHub-native sub-issues and adds
+  dependency edges only where one child task truly blocks another
 
 The watchdog currently:
 
@@ -242,6 +244,9 @@ Useful environment variables:
 - `OPENREACTOR_TRIAGE_MODEL`
 - `OPENREACTOR_TRIAGE_REASONING_EFFORT`
 - `OPENREACTOR_TRIAGE_SERVICE_TIER`
+- `OPENREACTOR_PLANNER_MODEL`
+- `OPENREACTOR_PLANNER_REASONING_EFFORT`
+- `OPENREACTOR_PLANNER_SERVICE_TIER`
 - `OPENREACTOR_AGENT_MODEL`
 - `OPENREACTOR_AGENT_REASONING_EFFORT`
 - `OPENREACTOR_AGENT_SERVICE_TIER`

--- a/ops/reactor.env.example
+++ b/ops/reactor.env.example
@@ -24,6 +24,10 @@ GITHUB_APP_PRIVATE_KEY=
 # OPENREACTOR_TRIAGE_REASONING_EFFORT=low
 # Optional. Leave unset unless you have a known-good service tier for this Codex build/account.
 # OPENREACTOR_TRIAGE_SERVICE_TIER=
+# OPENREACTOR_PLANNER_MODEL=gpt-5.4
+# OPENREACTOR_PLANNER_REASONING_EFFORT=high
+# Optional. Leave unset unless you have a known-good service tier for this Codex build/account.
+# OPENREACTOR_PLANNER_SERVICE_TIER=
 # OPENREACTOR_AGENT_MODEL=gpt-5.4
 # OPENREACTOR_AGENT_REASONING_EFFORT=medium
 # Optional. Leave unset unless you have a known-good service tier for this Codex build/account.

--- a/prompts/planner-agent.md
+++ b/prompts/planner-agent.md
@@ -15,5 +15,9 @@ Rules:
 - Prefer 2 to 5 child issues unless the work is truly trivial.
 - Each child issue should be independently actionable by one implementation agent.
 - Child issues should not be written as public intake requests. Do not start their titles with `[Request]` and do not include the public request marker.
+- OpenReactor will create the child issues as GitHub sub-issues of the parent.
+- Use each child issue's `dependsOn` array to reference zero-based indexes of earlier or later child issues that must complete first.
+- Only add dependencies for true blockers. Leave `dependsOn` empty when tasks can proceed in parallel.
+- Prefer the smallest dependency graph that preserves correctness.
 - If a child issue requires human setup, include exact continuation instructions in that child issue body instead of discarding the direction.
 - If the parent request is not worth pursuing, reject it clearly rather than decomposing it.

--- a/reactor/agent-result.schema.json
+++ b/reactor/agent-result.schema.json
@@ -67,9 +67,16 @@
               "body": {
                 "type": "string",
                 "minLength": 20
+              },
+              "dependsOn": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "minimum": 0
+                }
               }
             },
-            "required": ["title", "body"]
+            "required": ["title", "body", "dependsOn"]
           }
         }
       },

--- a/reactor/config.ts
+++ b/reactor/config.ts
@@ -29,6 +29,9 @@ export interface OrchestratorConfig {
   triageModel: string;
   triageReasoningEffort: string;
   triageServiceTier: string;
+  plannerModel: string;
+  plannerReasoningEffort: string;
+  plannerServiceTier: string;
   agentModel: string;
   agentReasoningEffort: string;
   agentServiceTier: string;
@@ -73,6 +76,15 @@ export function loadConfig(repoRoot = process.cwd()): OrchestratorConfig {
     triageReasoningEffort:
       clean(process.env.OPENREACTOR_TRIAGE_REASONING_EFFORT) || "low",
     triageServiceTier: clean(process.env.OPENREACTOR_TRIAGE_SERVICE_TIER),
+    plannerModel:
+      clean(process.env.OPENREACTOR_PLANNER_MODEL) ||
+      clean(process.env.OPENREACTOR_AGENT_MODEL) ||
+      "gpt-5.4",
+    plannerReasoningEffort:
+      clean(process.env.OPENREACTOR_PLANNER_REASONING_EFFORT) || "high",
+    plannerServiceTier:
+      clean(process.env.OPENREACTOR_PLANNER_SERVICE_TIER) ||
+      clean(process.env.OPENREACTOR_AGENT_SERVICE_TIER),
     agentModel: clean(process.env.OPENREACTOR_AGENT_MODEL) || "gpt-5.4",
     agentReasoningEffort:
       clean(process.env.OPENREACTOR_AGENT_REASONING_EFFORT) || "medium",

--- a/reactor/github.ts
+++ b/reactor/github.ts
@@ -11,6 +11,7 @@ const installationTokenCache = new Map<string, { token: string; expiresAt: numbe
 const installationIdCache = new Map<string, string>();
 
 export interface GitHubIssue {
+  id?: number;
   number: number;
   title: string;
   body: string | null;
@@ -217,6 +218,36 @@ export class GitHubClient {
           state: "open"
         })
       }
+    );
+  }
+
+  async addSubIssue(parentIssueNumber: number, subIssueId: number): Promise<void> {
+    await this.request(
+      `/repos/${this.config.owner}/${this.config.repo}/issues/${parentIssueNumber}/sub_issues`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          sub_issue_id: subIssueId
+        })
+      }
+    );
+  }
+
+  async addBlockedByDependency(issueNumber: number, blockingIssueId: number): Promise<void> {
+    await this.request(
+      `/repos/${this.config.owner}/${this.config.repo}/issues/${issueNumber}/dependencies/blocked_by`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          issue_id: blockingIssueId
+        })
+      }
+    );
+  }
+
+  async listBlockedByDependencies(issueNumber: number): Promise<GitHubIssue[]> {
+    return this.request<GitHubIssue[]>(
+      `/repos/${this.config.owner}/${this.config.repo}/issues/${issueNumber}/dependencies/blocked_by?per_page=100`
     );
   }
 

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -57,6 +57,7 @@ class Reactor {
   private readonly github: GitHubClient;
   private readonly activeRuns = new Map<number, ActiveRun>();
   private readonly pendingRetries = new Set<number>();
+  private readonly blockedDependencyCache = new Map<number, boolean>();
   private stopped = false;
 
   constructor(private readonly dryRun: boolean) {
@@ -177,6 +178,7 @@ class Reactor {
   }
 
   private async tick(): Promise<void> {
+    this.blockedDependencyCache.clear();
     await this.reconcileStaleActiveRuns();
 
     const discussionRequeuedIssues = this.dryRun
@@ -192,7 +194,12 @@ class Reactor {
     ).filter((issue) => this.isRelevantIssue(issue));
 
     if (this.dryRun) {
-      const eligible = candidates.filter((issue) => this.isEligibleForClaim(issue));
+      const eligible = [];
+      for (const issue of candidates) {
+        if (await this.isEligibleForClaim(issue)) {
+          eligible.push(issue);
+        }
+      }
       console.log(
         JSON.stringify(
           {
@@ -220,7 +227,7 @@ class Reactor {
         break;
       }
 
-      if (!this.isEligibleForClaim(issue)) {
+      if (!(await this.isEligibleForClaim(issue))) {
         continue;
       }
 
@@ -672,7 +679,7 @@ class Reactor {
     return true;
   }
 
-  private isEligibleForClaim(issue: GitHubIssue): boolean {
+  private async isEligibleForClaim(issue: GitHubIssue): Promise<boolean> {
     if (this.activeRuns.has(issue.number)) {
       return false;
     }
@@ -699,6 +706,10 @@ class Reactor {
     }
 
     if (labels.has(this.config.acceptedLabel) || labels.has(this.config.rejectedLabel)) {
+      return false;
+    }
+
+    if (await this.hasOpenBlockingDependencies(issue.number)) {
       return false;
     }
 
@@ -1020,7 +1031,35 @@ class Reactor {
               body,
               labels: inheritedLabels
             });
+            if (!createdIssue.id) {
+              throw new Error(
+                `GitHub did not return an id for decomposed issue #${createdIssue.number}.`
+              );
+            }
+            await this.github.addSubIssue(issueNumber, createdIssue.id);
             createdIssues.push(createdIssue);
+          }
+
+          for (const [index, child] of result.decomposition.childIssues.entries()) {
+            const issue = createdIssues[index];
+            if (!issue?.id) {
+              throw new Error(`Missing GitHub id for decomposed child issue at index ${index}.`);
+            }
+
+            for (const dependencyIndex of normalizeDependencyIndexes(
+              child.dependsOn,
+              result.decomposition.childIssues.length,
+              index
+            )) {
+              const blockingIssue = createdIssues[dependencyIndex];
+              if (!blockingIssue?.id) {
+                throw new Error(
+                  `Missing GitHub id for dependency child issue at index ${dependencyIndex}.`
+                );
+              }
+
+              await this.github.addBlockedByDependency(issue.number, blockingIssue.id);
+            }
           }
 
           await this.syncIssueStatusComment(issueNumber, {
@@ -1118,6 +1157,17 @@ class Reactor {
     }
 
     await this.github.updatePullRequest(pullRequestNumber, { body: nextBody });
+  }
+
+  private async hasOpenBlockingDependencies(issueNumber: number): Promise<boolean> {
+    if (this.blockedDependencyCache.has(issueNumber)) {
+      return this.blockedDependencyCache.get(issueNumber) ?? false;
+    }
+
+    const blockedByIssues = await this.github.listBlockedByDependencies(issueNumber);
+    const hasOpenDependencies = blockedByIssues.some((issue) => issue.state === "open");
+    this.blockedDependencyCache.set(issueNumber, hasOpenDependencies);
+    return hasOpenDependencies;
   }
 
   private async updateLiveStatus(): Promise<void> {
@@ -1457,6 +1507,24 @@ function ensureParentLinkInDecomposedIssueBody(issue: GitHubIssue, body: string)
     "",
     trimmed
   ].join("\n");
+}
+
+function normalizeDependencyIndexes(
+  indexes: number[] | null | undefined,
+  totalChildren: number,
+  selfIndex: number
+): number[] {
+  return Array.from(
+    new Set(
+      (indexes ?? []).filter(
+        (value) =>
+          Number.isInteger(value) &&
+          value >= 0 &&
+          value < totalChildren &&
+          value !== selfIndex
+      )
+    )
+  ).sort((left, right) => left - right);
 }
 
 function parseIssueNumberFromBranch(branchPrefix: string, branchName: string): number | null {

--- a/reactor/runner.ts
+++ b/reactor/runner.ts
@@ -43,6 +43,7 @@ export interface HumanHandoff {
 export interface DecompositionChildIssue {
   title: string;
   body: string;
+  dependsOn: number[];
 }
 
 export interface DecompositionPlan {
@@ -553,9 +554,9 @@ async function spawnCodexPlannerAgent(input: {
   await fs.writeFile(promptPath, prompt, "utf8");
 
   const args = buildCodexArgs({
-    model: config.agentModel,
-    reasoningEffort: config.agentReasoningEffort,
-    serviceTier: config.agentServiceTier,
+    model: config.plannerModel,
+    reasoningEffort: config.plannerReasoningEffort,
+    serviceTier: config.plannerServiceTier,
     fullAccess: true,
     outputSchemaPath: schemaPath,
     outputPath: resultPath
@@ -614,9 +615,9 @@ async function spawnCodexPlannerAgent(input: {
     executionTemplate: {
       providerKey: "codex",
       providerLabel: providerLabelFor("codex"),
-      model: config.agentModel,
-      reasoningEffort: config.agentReasoningEffort,
-      serviceTier: config.agentServiceTier ?? null,
+      model: config.plannerModel,
+      reasoningEffort: config.plannerReasoningEffort,
+      serviceTier: config.plannerServiceTier ?? null,
       toolName: "spawn_codex_planner_agent",
       toolLabel: getAgentTool("spawn_codex_planner_agent").label,
       primaryUse: getAgentTool("spawn_codex_planner_agent").primaryUse
@@ -844,6 +845,7 @@ function buildAgentPrompt(
             `- This issue was dispatched via ${tool.label}. Your primary job is to decide whether the request should be decomposed into multiple smaller issues instead of being implemented directly.`,
             "- Use prompts/planner-agent.md as the planning-specific rule set for this run.",
             "- If the request is worth pursuing but too large, return `decomposed` with a structured decomposition plan instead of `rejected`.",
+            "- When decomposing, use `dependsOn` only for true blocking relationships between child tasks. Leave it empty for tasks that can proceed in parallel.",
             "- Do not open a PR for the oversized parent issue itself."
           ]
       : [


### PR DESCRIPTION
## Summary
- give the planner its own high-reasoning config path
- let decomposed work create GitHub-native sub-issues and issue dependencies
- skip claiming child issues whose blocking dependencies are still open

## Verification
- bun run check
- bun -e 'import { loadConfig } from "./reactor/config"; const c = loadConfig(process.cwd()); console.log(JSON.stringify({ plannerModel: c.plannerModel, plannerReasoningEffort: c.plannerReasoningEffort }, null, 2));'