### PR TITLE
Prompt agents to write better PR implementation reports

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -147,6 +147,12 @@
   agent exits, so a reactor-owned final refresh is the deterministic way to
   make the PR body reflect the agent that actually finished the work.
 
+- Decision: prompt issue agents to include a short implementation report in PR
+  descriptions, not just metadata and test output.
+  Reason: humans need a useful explanation of what changed, why the approach
+  was chosen, what was discovered, and how problems were handled when reading
+  OpenReactor-created PRs.
+
 - Decision: once a running issue blows past roughly eight iterations without a
   PR, the watchdog should treat it as a workflow fault and open concrete
   OpenReactor repair work instead of assuming more retries are productive.

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -60,6 +60,9 @@ maintainer consideration.
 - OpenReactor should refresh PR execution footers after the run finishes so
   the final PR body deterministically reflects the implementation agent that
   actually produced the result.
+- OpenReactor should instruct implementation agents to leave a concise,
+  human-useful implementation report in PR descriptions instead of relying only
+  on raw metadata or a bare checklist.
 - When OpenReactor decomposes an oversized issue, it should create GitHub-native
   sub-issues for the child tasks and add issue dependencies only for true
   blocking relationships, so independent child tasks can still run in

--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ The reactor currently:
   OpenReactor has that information directly
 - refreshes PR execution footers after a run completes so the final PR body
   reflects the implementation agent that actually finished the work
+- instructs issue agents to leave a concise implementation report in PR
+  descriptions so humans can see what changed, why it was built that way, what
+  was discovered, and how problems were handled
 - decomposes oversized requests into GitHub-native sub-issues and adds
   dependency edges only where one child task truly blocks another
 

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -149,6 +149,15 @@ If accepted and fully complete:
 - ensure the branch is pushed
 - open or update a PR
 - enable auto-merge unless the PR needs human intervention or manual review
+- make the PR body useful to a human reviewer, not just valid for automation
+- include a concise implementation report in the PR description covering:
+  - what changed
+  - why you chose this approach
+  - key discoveries or constraints you uncovered while implementing it
+  - any meaningful issues you ran into and how you resolved them
+  - remaining follow-ups or risks, if any
+- keep that report public-facing and concrete; do not include hidden chain-of-thought
+- prefer short sections and bullets over long narrative prose
 - if you accepted a narrower or softened version of a rigid request, say so
   clearly in the issue comment and PR body so the product decision is legible
 - if the PR already exists and is blocked by merge conflicts, keep the same PR alive and update the branch until it is mergeable again
@@ -177,6 +186,35 @@ Use this to make PR creation idempotent:
 ```bash
 bun run reactor:tool ensure-pr --issue "$OPENREACTOR_ISSUE_NUMBER" --branch "$OPENREACTOR_BRANCH_NAME" --title "..." --body-file ./path/to/pr-body.md
 ```
+
+When writing `pr-body.md`, prefer a structure like:
+
+```md
+## Summary
+Short explanation of what shipped.
+
+## Why This Approach
+Why this implementation was chosen.
+
+## Key Changes
+- ...
+
+## Discoveries
+- ...
+
+## Issues Encountered
+- ...
+
+## Verification
+- ...
+
+## Follow-ups
+- ...
+```
+
+Not every section needs multiple bullets, but do not leave the PR description
+as only a title, a bare summary, or a test checklist when useful implementation
+context exists.
 
 If the PR needs human intervention or explicit manual review, opt out:
 


### PR DESCRIPTION
## Summary
- tell issue agents to leave a concise implementation report in PR descriptions
- document the expectation in OpenReactor workflow docs
- keep the execution footer as the machine-readable metadata layer

Closes #231

## Verification
- prompt/docs change only