### PR TITLE
Attach issue reference images to Codex runs

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -189,3 +189,10 @@
   Reason: the current MVP has no separate storage system for website uploads,
   but maintainers still need request images to survive the intake flow and stay
   visible to issue agents inside GitHub.
+
+- Decision: when an issue carries reference images, download them into the
+  issue run directory and attach them directly to Codex agent runs as real
+  image input.
+  Reason: markdown image links in the issue body are not a reliable substitute
+  for actual multimodal input when an agent needs to inspect a UI reference or
+  other uploaded image while implementing the issue.

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -57,6 +57,11 @@ maintainer consideration.
 - OpenReactor should surface hard execution facts in public workflow artifacts
   where possible, such as provider, model, reasoning effort, and runtime
   duration, instead of relying only on narrative summaries.
+- If an issue includes reference images, OpenReactor should treat them as
+  first-class input. Codex-capable runs should receive the actual image files,
+  not only markdown links to them. If another implementation path cannot
+  accept deterministic image attachments yet, OpenReactor should route that
+  issue through a path that can.
 - OpenReactor should refresh PR execution footers after the run finishes so
   the final PR body deterministically reflects the implementation agent that
   actually produced the result.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ What is live now:
 - signed-in GitHub attribution for website submissions, while anonymous submission still remains allowed
 - trusted maintainer steering and authenticated submitter identity propagation
   through decomposed child issues
+- reference image uploads that survive intake, get embedded into the GitHub
+  issue, and are attached directly to Codex-based issue runs as real image
+  input
 - local reactor loop for autonomous issue handling
 
 The website/backend and the reactor are separate:
@@ -204,6 +207,9 @@ The reactor currently:
 - instructs issue agents to leave a concise implementation report in PR
   descriptions so humans can see what changed, why it was built that way, what
   was discovered, and how problems were handled
+- downloads reference images from issue bodies and discussion into the run
+  directory and attaches them to Codex runs as real image input instead of
+  leaving them as markdown links only
 - decomposes oversized requests into GitHub-native sub-issues and adds
   dependency edges only where one child task truly blocks another
 

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -10,9 +10,10 @@ You are the autonomous agent for one GitHub issue.
 4. Read `PRODUCT_CONSTITUTION.md` and `OPENREACTOR_WORKFLOW.md`.
 5. If you touch UI, read `UI_SYSTEM.md` before editing.
 6. Read the issue context file provided in the run directory.
-7. Read `progress.md` if it already exists.
-8. If `plan.json` exists, use it. If not, create it before coding.
-9. Prefer the repo-local helper commands when they make the workflow more reliable.
+7. If the issue context lists reference images, inspect them before making implementation decisions.
+8. Read `progress.md` if it already exists.
+9. If `plan.json` exists, use it. If not, create it before coding.
+10. Prefer the repo-local helper commands when they make the workflow more reliable.
 
 ## Your Authority
 
@@ -22,6 +23,9 @@ You are the autonomous agent for one GitHub issue.
 - Treat recent issue comments as part of the live spec. If the discussion has
   refined the request since the original issue body was written, work from the
   refined version.
+- Treat any attached reference images as part of the live spec too. They are
+  not decorative; they are part of the request input and should shape your
+  implementation choices.
 - Act like a discerning product manager, not a literal ticket fulfiller.
 - Use the issue as feedback and infer the best product move from it.
 - Do not reject a request solely because its exact threshold, hard cap, or

--- a/prompts/triage-agent.md
+++ b/prompts/triage-agent.md
@@ -14,6 +14,9 @@ Rules:
 - Classify the target surface as `main`, `playground`, or `openreactor-core`.
 - Treat the issue body and the recent issue discussion together as the current
   request. Comments can refine, narrow, or materially update the task.
+- If reference images are attached to the issue or its recent discussion,
+  treat them as part of the request input when deciding which implementation
+  path makes the most sense.
 - Classify the request's likely surface sensitivity as `low`, `medium`, or `high`.
 - Classify the current evidence strength for acting now as `weak`, `moderate`,
   or `strong`.

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -22,6 +22,7 @@ import {
   ensureIssueWorktree,
   ensureRuntimeDirectories,
   finalizeIssueAgentRun,
+  issueHasReferenceImages,
   issueRuntimePaths,
   listChangedFilesForBranch,
   readRunRecord,
@@ -779,14 +780,13 @@ class Reactor {
     selectedTriage?: TriageResult
   ): Promise<void> {
     const paths = issueRuntimePaths(this.config, issue.number);
-    const agentTool = isAgentToolName(selectedTriage?.toolName)
+    const requestedAgentTool = isAgentToolName(selectedTriage?.toolName)
       ? selectedTriage.toolName
       : existingRecord?.agentTool ?? DEFAULT_AGENT_TOOL;
     const record =
       existingRecord ??
       (await readRunRecord(paths)) ??
       (await createInitialRunRecord(issue, paths));
-    record.agentTool = agentTool;
     record.targetSurface = selectedTriage?.targetSurface ?? record.targetSurface;
     record.sensitivity = selectedTriage?.sensitivity ?? record.sensitivity;
     record.evidenceStrength = selectedTriage?.evidenceStrength ?? record.evidenceStrength;
@@ -794,8 +794,14 @@ class Reactor {
 
     try {
       const comments = await this.github.listIssueComments(issue.number);
+      const hasReferenceImages = issueHasReferenceImages(issue, comments);
+      const agentTool =
+        requestedAgentTool === "spawn_claude_ui_agent" && hasReferenceImages
+          ? "spawn_codex_issue_agent"
+          : requestedAgentTool;
+      record.agentTool = agentTool;
       await ensureIssueWorktree(this.config, paths);
-      await writeIssueContext(this.config, issue, paths, {
+      const referenceImages = await writeIssueContext(this.config, issue, paths, {
         targetSurface: record.targetSurface,
         sensitivity: record.sensitivity,
         evidenceStrength: record.evidenceStrength,
@@ -806,9 +812,17 @@ class Reactor {
         status: "in-progress",
         phase: existingRecord ? "retrying" : "reviewing",
         iteration: record.iteration + 1,
-        detail: existingRecord
-          ? `Retry iteration ${record.iteration + 1} is running after the previous attempt ended without a final decision.`
-          : "Full issue agent is reviewing the request and deciding the best product change."
+        detail: [
+          existingRecord
+            ? `Retry iteration ${record.iteration + 1} is running after the previous attempt ended without a final decision.`
+            : "Full issue agent is reviewing the request and deciding the best product change.",
+          requestedAgentTool === "spawn_claude_ui_agent" && hasReferenceImages
+            ? "OpenReactor routed this run through Codex because reference images are attached and the current Claude CLI path does not yet support deterministic image attachments."
+            : "",
+          referenceImages.length
+            ? `Attached ${referenceImages.length} reference image${referenceImages.length === 1 ? "" : "s"} to the agent input.`
+            : ""
+        ].filter(Boolean).join(" ")
       });
 
       const accessToken = await this.github.getAgentAccessToken();
@@ -817,7 +831,8 @@ class Reactor {
         issue,
         paths,
         record,
-        githubToken: accessToken
+        githubToken: accessToken,
+        referenceImages
       });
 
       this.activeRuns.set(issue.number, activeRun);
@@ -828,7 +843,7 @@ class Reactor {
         phase: existingRecord ? "retry-startup" : "startup",
         error,
         record,
-        selectedTool: agentTool
+        selectedTool: record.agentTool ?? requestedAgentTool
       });
     }
   }

--- a/reactor/runner.ts
+++ b/reactor/runner.ts
@@ -121,6 +121,7 @@ export interface IssueRuntimePaths {
   triageResultPath: string;
   triageLogPath: string;
   contextPath: string;
+  referenceImagesDir: string;
   progressPath: string;
   tasksPath: string;
   planPath: string;
@@ -159,6 +160,13 @@ interface TrustedSubmitterSignal {
   source: "issue-author" | "trusted-label";
 }
 
+export interface RunReferenceImage {
+  sourceUrl: string;
+  localPath: string;
+  source: "issue-body" | "discussion";
+  sourceLabel: string;
+}
+
 export function issueRuntimePaths(config: OrchestratorConfig, issueNumber: number): IssueRuntimePaths {
   const runDir = path.join(config.runsDir, `issue-${issueNumber}`);
   const worktreePath = path.join(config.worktreesDir, `issue-${issueNumber}`);
@@ -173,6 +181,7 @@ export function issueRuntimePaths(config: OrchestratorConfig, issueNumber: numbe
     triageResultPath: path.join(runDir, "triage.result.json"),
     triageLogPath: path.join(runDir, "triage.log"),
     contextPath: path.join(runDir, "context.md"),
+    referenceImagesDir: path.join(runDir, "reference-images"),
     progressPath: path.join(runDir, "progress.md"),
     tasksPath: path.join(runDir, "tasks.md"),
     planPath: path.join(runDir, "plan.json")
@@ -209,10 +218,11 @@ export async function writeIssueContext(
     evidenceSummary?: string;
   },
   discussionComments: GitHubIssueComment[] = []
-): Promise<void> {
+): Promise<RunReferenceImage[]> {
   const labels = issue.labels.map((label) => label.name).filter(Boolean).join(", ") || "_None_";
   const maintainerSteering = getMaintainerSteeringSignal(config, issue);
   const trustedSubmitter = getTrustedSubmitterSignal(config, issue);
+  const referenceImages = await prepareRunReferenceImages(issue, paths, discussionComments);
 
   const content = [
     "# Issue Context",
@@ -245,6 +255,10 @@ export async function writeIssueContext(
     "",
     formatRecentDiscussion(discussionComments),
     "",
+    "## Reference Images",
+    "",
+    formatReferenceImageContext(config, paths, referenceImages),
+    "",
     "## Derived Guidance",
     "",
     maintainerSteering
@@ -267,6 +281,7 @@ export async function writeIssueContext(
     `- Task tracker: ${relativeFromRepo(config, paths.tasksPath)}`,
     `- Plan file: ${relativeFromRepo(config, paths.planPath)}`,
     `- Run state: ${relativeFromRepo(config, paths.runFilePath)}`,
+    `- Reference images: ${relativeFromRepo(config, paths.referenceImagesDir)}`,
     "",
     "## Product Docs To Read",
     "",
@@ -317,6 +332,8 @@ export async function writeIssueContext(
   );
 
   await ensurePlanScaffold(paths, issue);
+
+  return referenceImages;
 }
 
 export async function createInitialRunRecord(
@@ -429,6 +446,7 @@ export async function spawnIssueAgent(input: {
   paths: IssueRuntimePaths;
   record: RunRecord;
   githubToken: string;
+  referenceImages?: RunReferenceImage[];
 }): Promise<ActiveRun> {
   const tool = getAgentTool(input.record.agentTool);
   if (tool.name === "spawn_codex_planner_agent") {
@@ -447,6 +465,7 @@ async function spawnCodexIssueAgent(input: {
   paths: IssueRuntimePaths;
   record: RunRecord;
   githubToken: string;
+  referenceImages?: RunReferenceImage[];
 }): Promise<ActiveRun> {
   const { config, issue, paths, githubToken } = input;
   const iteration = input.record.iteration + 1;
@@ -464,7 +483,8 @@ async function spawnCodexIssueAgent(input: {
     serviceTier: config.agentServiceTier,
     fullAccess: true,
     outputSchemaPath: schemaPath,
-    outputPath: resultPath
+    outputPath: resultPath,
+    imagePaths: input.referenceImages?.map((image) => image.localPath)
   });
 
   const child = spawn("codex", args, {
@@ -542,6 +562,7 @@ async function spawnCodexPlannerAgent(input: {
   paths: IssueRuntimePaths;
   record: RunRecord;
   githubToken: string;
+  referenceImages?: RunReferenceImage[];
 }): Promise<ActiveRun> {
   const { config, issue, paths, githubToken } = input;
   const iteration = input.record.iteration + 1;
@@ -559,7 +580,8 @@ async function spawnCodexPlannerAgent(input: {
     serviceTier: config.plannerServiceTier,
     fullAccess: true,
     outputSchemaPath: schemaPath,
-    outputPath: resultPath
+    outputPath: resultPath,
+    imagePaths: input.referenceImages?.map((image) => image.localPath)
   });
 
   const child = spawn("codex", args, {
@@ -725,6 +747,7 @@ export async function runIssueTriage(input: {
   const { config, issue, paths, githubToken } = input;
   const schemaPath = path.join(config.repoRoot, "reactor", "triage-result.schema.json");
   const prompt = buildTriagePrompt(config, issue, input.comments ?? []);
+  const referenceImages = await prepareRunReferenceImages(issue, paths, input.comments ?? []);
 
   await fs.mkdir(paths.runDir, { recursive: true });
   await fs.writeFile(paths.triagePromptPath, prompt, "utf8");
@@ -735,7 +758,8 @@ export async function runIssueTriage(input: {
     serviceTier: config.triageServiceTier,
     fullAccess: false,
     outputSchemaPath: schemaPath,
-    outputPath: paths.triageResultPath
+    outputPath: paths.triageResultPath,
+    imagePaths: referenceImages.map((image) => image.localPath)
   });
 
   const startedAt = new Date().toISOString();
@@ -1221,6 +1245,37 @@ async function runCommandCapture(command: string, args: string[]): Promise<strin
   return stdout;
 }
 
+export function issueHasReferenceImages(
+  issue: Pick<GitHubIssue, "body">,
+  discussionComments: GitHubIssueComment[] = []
+): boolean {
+  return collectReferenceImageCandidates(issue, discussionComments).length > 0;
+}
+
+export async function prepareRunReferenceImages(
+  issue: Pick<GitHubIssue, "body">,
+  paths: Pick<IssueRuntimePaths, "referenceImagesDir">,
+  discussionComments: GitHubIssueComment[] = []
+): Promise<RunReferenceImage[]> {
+  const candidates = collectReferenceImageCandidates(issue, discussionComments);
+  if (!candidates.length) {
+    return [];
+  }
+
+  await fs.rm(paths.referenceImagesDir, { recursive: true, force: true });
+  await fs.mkdir(paths.referenceImagesDir, { recursive: true });
+
+  const images: RunReferenceImage[] = [];
+  for (const [index, candidate] of candidates.entries()) {
+    const downloaded = await downloadReferenceImage(candidate, paths.referenceImagesDir, index + 1);
+    if (downloaded) {
+      images.push(downloaded);
+    }
+  }
+
+  return images;
+}
+
 async function attachProcessLogging(
   child: ChildProcessWithoutNullStreams,
   logPath: string
@@ -1250,6 +1305,7 @@ function buildCodexArgs(input: {
   fullAccess: boolean;
   outputSchemaPath: string;
   outputPath: string;
+  imagePaths?: string[];
 }): string[] {
   const args = [
     "-m",
@@ -1260,6 +1316,10 @@ function buildCodexArgs(input: {
 
   if (input.serviceTier) {
     args.push("-c", `service_tier="${input.serviceTier}"`);
+  }
+
+  for (const imagePath of input.imagePaths ?? []) {
+    args.push("-i", imagePath);
   }
 
   if (input.fullAccess) {
@@ -1279,6 +1339,171 @@ function buildCodexArgs(input: {
   );
 
   return args;
+}
+
+interface ReferenceImageCandidate {
+  url: string;
+  source: "issue-body" | "discussion";
+  sourceLabel: string;
+}
+
+function collectReferenceImageCandidates(
+  issue: Pick<GitHubIssue, "body">,
+  discussionComments: GitHubIssueComment[]
+): ReferenceImageCandidate[] {
+  const seen = new Set<string>();
+  const candidates: ReferenceImageCandidate[] = [];
+
+  const pushUnique = (candidate: ReferenceImageCandidate): void => {
+    const normalizedUrl = normalizeReferenceImageUrl(candidate.url);
+    if (!normalizedUrl || seen.has(normalizedUrl)) {
+      return;
+    }
+
+    seen.add(normalizedUrl);
+    candidates.push({
+      ...candidate,
+      url: normalizedUrl
+    });
+  };
+
+  for (const url of extractImageUrls(issue.body ?? "")) {
+    pushUnique({
+      url,
+      source: "issue-body",
+      sourceLabel: "Issue body"
+    });
+  }
+
+  for (const comment of discussionComments) {
+    const author = comment.user?.login ? `@${comment.user.login}` : "a discussion comment";
+    for (const url of extractImageUrls(comment.body)) {
+      pushUnique({
+        url,
+        source: "discussion",
+        sourceLabel: `Discussion from ${author} on ${comment.updated_at}`
+      });
+    }
+  }
+
+  return candidates;
+}
+
+function extractImageUrls(markdown: string): string[] {
+  const urls: string[] = [];
+  const markdownPattern = /!\[[^\]]*\]\((https?:\/\/[^)\s]+)\)/gi;
+  const htmlPattern = /<img\b[^>]*\bsrc=["'](https?:\/\/[^"']+)["'][^>]*>/gi;
+  const directImagePattern = /\bhttps?:\/\/[^\s<>()]+?\.(?:png|jpe?g|gif|webp|svg)(?:\?[^\s<>()]+)?\b/gi;
+
+  for (const pattern of [markdownPattern, htmlPattern, directImagePattern]) {
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(markdown)) !== null) {
+      const url = match[1] ?? match[0];
+      if (url) {
+        urls.push(url);
+      }
+    }
+  }
+
+  return urls;
+}
+
+function normalizeReferenceImageUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+async function downloadReferenceImage(
+  candidate: ReferenceImageCandidate,
+  targetDir: string,
+  index: number
+): Promise<RunReferenceImage | null> {
+  let response: Response;
+  try {
+    response = await fetch(candidate.url);
+  } catch {
+    return null;
+  }
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().startsWith("image/")) {
+    return null;
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const extension = pickReferenceImageExtension(candidate.url, contentType);
+  const fileName = `${String(index).padStart(2, "0")}-${sanitizeReferenceImageBaseName(candidate.url)}${extension}`;
+  const localPath = path.join(targetDir, fileName);
+  await fs.writeFile(localPath, bytes);
+
+  return {
+    sourceUrl: candidate.url,
+    localPath,
+    source: candidate.source,
+    sourceLabel: candidate.sourceLabel
+  };
+}
+
+function pickReferenceImageExtension(url: string, contentType: string): string {
+  const fromUrl = path.extname(new URL(url).pathname).toLowerCase();
+  if (fromUrl) {
+    return fromUrl;
+  }
+
+  const mimeType = contentType.toLowerCase().split(";")[0].trim();
+  switch (mimeType) {
+    case "image/jpeg":
+      return ".jpg";
+    case "image/png":
+      return ".png";
+    case "image/gif":
+      return ".gif";
+    case "image/webp":
+      return ".webp";
+    case "image/svg+xml":
+      return ".svg";
+    default:
+      return ".img";
+  }
+}
+
+function sanitizeReferenceImageBaseName(url: string): string {
+  const pathname = new URL(url).pathname;
+  const baseName = path.basename(pathname, path.extname(pathname)).trim().toLowerCase();
+  const sanitized = baseName.replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return sanitized || "reference-image";
+}
+
+function formatReferenceImageContext(
+  config: OrchestratorConfig,
+  paths: IssueRuntimePaths,
+  referenceImages: RunReferenceImage[]
+): string {
+  if (!referenceImages.length) {
+    return "_No reference images were detected on the issue body or recent discussion._";
+  }
+
+  return referenceImages
+    .map((image, index) =>
+      [
+        `${index + 1}. ${image.sourceLabel}`,
+        `   - Local file: ${relativeFromRepo(config, image.localPath)}`,
+        `   - Source URL: ${image.sourceUrl}`
+      ].join("\n")
+    )
+    .join("\n");
 }
 
 function buildClaudeArgs(input: {


### PR DESCRIPTION
## Summary
- download issue reference images into the per-run directory
- attach them directly to Codex triage, planner, and implementation runs with `codex exec --image`
- route image-backed Claude UI requests through Codex until the Claude CLI path supports deterministic image attachments

## Why This Approach
Issue text alone is not enough for real multimodal input. This makes reference images first-class input for the coding agents using the CLI capability Codex already exposes.

## Key Changes
- detect image links in issue bodies and recent discussion
- persist downloaded images under the run directory and surface them in `context.md`
- pass local image files into Codex runs
- update prompts and workflow docs so image references are treated as part of the live spec

## Verification
- `bun run check`
- synthetic smoke test confirming a linked PNG is downloaded into `.openreactor/runs/.../reference-images/` and written into the issue context
