### PR TITLE
Add repo-local OpenReactor state bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 .wrangler
 .dev.vars
-.openreactor
+.openreactor/*
+!.openreactor/repo/
+!.openreactor/repo/**
 public/styles.css

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -195,4 +195,13 @@
   image input.
   Reason: markdown image links in the issue body are not a reliable substitute
   for actual multimodal input when an agent needs to inspect a UI reference or
-  other uploaded image while implementing the issue.
+  other uploaded image while implementing the issue, and Claude Code can read
+  image files by local path when that directory is included in its allowed
+  scope.
+
+- Decision: start separating shared OpenReactor runtime code from repo-local
+  product steering state by introducing a committed `.openreactor/repo/`
+  directory.
+  Reason: OpenReactor should eventually manage many repos, and each repo needs
+  its own product memory, roadmap, and constitution without having to vendor
+  the whole OpenReactor engine into that repo.

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -37,6 +37,9 @@ maintainer consideration.
   explicitly labeled OpenReactor issues.
 - Trusted maintainer steering should come from real GitHub authorship or
   trusted OpenReactor-applied labels, not from free-text body fields.
+- Product-specific memory and steering should live with the target repo in a
+  committed repo-local state layer, instead of being trapped only in the
+  shared OpenReactor engine repo.
 - Readability and recoverability matter more than cleverness in core runtime
   code.
 - OpenReactor should be allowed to evolve as a process, not frozen as a rigid
@@ -87,6 +90,25 @@ This workflow applies to:
 - triage and orchestration rules
 - deployment/merge policy
 - privileged internal or admin behavior
+
+## Repo-local state
+
+OpenReactor should separate:
+
+- shared engine/runtime code
+- repo-local product steering state
+
+The repo-local state is where product-specific direction, roadmap, and durable
+memory should live for a managed repository. The current committed layout is:
+
+- `.openreactor/repo/README.md`
+- `.openreactor/repo/PRODUCT_SPEC.md`
+- `.openreactor/repo/PRODUCT_CONSTITUTION.md`
+- `.openreactor/repo/ROADMAP.md`
+- `.openreactor/repo/MEMORY.md`
+
+When those files exist, issue agents and triage should prefer them over the
+legacy top-level product docs.
 
 ## OpenReactor proposals
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,31 @@ What it did need was a clearer policy split:
 OpenReactor issues should carry the `openreactor-core` label so they are not
 confused with normal website/product feedback.
 
+## Repo-local State
+
+OpenReactor is moving toward a split between:
+
+- the shared OpenReactor engine, which stays centralized
+- the repo-local product steering state, which travels with the target repo
+
+The first committed shape for that repo-local state is:
+
+- `.openreactor/repo/README.md`
+- `.openreactor/repo/PRODUCT_SPEC.md`
+- `.openreactor/repo/PRODUCT_CONSTITUTION.md`
+- `.openreactor/repo/ROADMAP.md`
+- `.openreactor/repo/MEMORY.md`
+
+When those files exist, the reactor prefers them over the legacy top-level
+product docs. This lets a target repo keep its own product direction and memory
+without needing to vendor the whole OpenReactor runtime into the repo.
+
+Bootstrap that repo-local steering layer with:
+
+```bash
+bun run reactor:tool init-repo-state
+```
+
 ## Running The Reactor
 
 The repository includes the machine-local orchestration loop under

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -7,8 +7,8 @@ You are the autonomous agent for one GitHub issue.
 1. Read `prompts/product-context.md`.
 2. Read `prompts/quality-gates.md`.
 3. Read `CONSTITUTION.md`.
-4. Read `PRODUCT_CONSTITUTION.md` and `OPENREACTOR_WORKFLOW.md`.
-5. If you touch UI, read `UI_SYSTEM.md` before editing.
+4. Read the repo-local product constitution under `.openreactor/repo/` when present, otherwise `PRODUCT_CONSTITUTION.md`, and read `OPENREACTOR_WORKFLOW.md`.
+5. If you touch UI, read the repo-local UI system file when present, otherwise `UI_SYSTEM.md`, before editing.
 6. Read the issue context file provided in the run directory.
 7. If the issue context lists reference images, inspect them before making implementation decisions.
 8. Read `progress.md` if it already exists.
@@ -61,9 +61,11 @@ You are the autonomous agent for one GitHub issue.
   maintainer steering,
   do not reject it solely for roadmap fit, product-direction fit, or
   constitution-fit concerns; still enforce safety and feasibility constraints.
-- You may update shared prompts, `CONSTITUTION.md`,
-  `PRODUCT_CONSTITUTION.md`, `OPENREACTOR_WORKFLOW.md`, `MEMORY.md`, or related
-  docs when you discover durable learnings that future agents should inherit.
+- You may update shared prompts, `CONSTITUTION.md`, the repo-local product
+  constitution or memory files under `.openreactor/repo/` when present,
+  otherwise `PRODUCT_CONSTITUTION.md` and `MEMORY.md`, `OPENREACTOR_WORKFLOW.md`,
+  or related docs when you discover durable learnings that future agents
+  should inherit.
 - If a feature requires a human-only step, you should prepare the code and handoff cleanly instead of pretending the task is complete.
 - Do not reject a request solely because it requires human-only setup such as
   API keys, OAuth registration, or account provisioning if the product

--- a/prompts/product-context.md
+++ b/prompts/product-context.md
@@ -32,13 +32,13 @@ Core rules:
 
 Always read and follow these local documents before deciding:
 
-- `PRODUCT_SPEC.md`
+- `.openreactor/repo/PRODUCT_SPEC.md` when present, otherwise `PRODUCT_SPEC.md`
 - `CONSTITUTION.md`
-- `PRODUCT_CONSTITUTION.md`
+- `.openreactor/repo/PRODUCT_CONSTITUTION.md` when present, otherwise `PRODUCT_CONSTITUTION.md`
 - `OPENREACTOR_WORKFLOW.md`
-- `ROADMAP.md`
-- `MEMORY.md`
-- `README.md`
+- `.openreactor/repo/ROADMAP.md` when present, otherwise `ROADMAP.md`
+- `.openreactor/repo/MEMORY.md` when present, otherwise `MEMORY.md`
+- `.openreactor/repo/README.md` when present, otherwise `README.md`
 
 Current product reality:
 
@@ -79,8 +79,8 @@ GitHub support contract:
 
 Shared-memory update rules:
 
-- Update `MEMORY.md` when a product or architecture decision changes.
-- Update `PRODUCT_CONSTITUTION.md` when a durable rule for public-facing
+- Update the repo-local memory file under `.openreactor/repo/` when present, otherwise `MEMORY.md`, when a product or architecture decision changes.
+- Update the repo-local product constitution under `.openreactor/repo/` when present, otherwise `PRODUCT_CONSTITUTION.md`, when a durable rule for public-facing
   product work changes.
 - Update `OPENREACTOR_WORKFLOW.md` when a durable OpenReactor process or
   workflow changes.

--- a/prompts/triage-agent.md
+++ b/prompts/triage-agent.md
@@ -9,8 +9,9 @@ implementation tool.
 Rules:
 
 - Read `prompts/product-context.md`, `prompts/issue-agent.md`, `CONSTITUTION.md`,
-  `PRODUCT_CONSTITUTION.md`, `OPENREACTOR_WORKFLOW.md`, and `ROADMAP.md` before
-  deciding.
+  the repo-local product constitution and roadmap under `.openreactor/repo/`
+  when present, otherwise `PRODUCT_CONSTITUTION.md` and `ROADMAP.md`, and
+  `OPENREACTOR_WORKFLOW.md` before deciding.
 - Classify the target surface as `main`, `playground`, or `openreactor-core`.
 - Treat the issue body and the recent issue discussion together as the current
   request. Comments can refine, narrow, or materially update the task.

--- a/reactor/repo-state.ts
+++ b/reactor/repo-state.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export const REPO_STATE_DIR = path.join(".openreactor", "repo");
+
+export interface RepoDocumentationPaths {
+  readme: string;
+  productSpec: string;
+  productConstitution: string;
+  roadmap: string;
+  memory: string;
+  uiSystem: string | null;
+}
+
+export async function resolveRepoDocumentationPaths(repoRoot: string): Promise<RepoDocumentationPaths> {
+  return {
+    readme: await preferRepoStateDoc(repoRoot, "README.md"),
+    productSpec: await preferRepoStateDoc(repoRoot, "PRODUCT_SPEC.md"),
+    productConstitution: await preferRepoStateDoc(repoRoot, "PRODUCT_CONSTITUTION.md"),
+    roadmap: await preferRepoStateDoc(repoRoot, "ROADMAP.md"),
+    memory: await preferRepoStateDoc(repoRoot, "MEMORY.md"),
+    uiSystem: await resolveOptionalRepoDoc(repoRoot, "UI_SYSTEM.md")
+  };
+}
+
+async function preferRepoStateDoc(repoRoot: string, fileName: string): Promise<string> {
+  const repoStatePath = path.join(repoRoot, REPO_STATE_DIR, fileName);
+  if (await pathExists(repoStatePath)) {
+    return repoStatePath;
+  }
+
+  return path.join(repoRoot, fileName);
+}
+
+async function resolveOptionalRepoDoc(repoRoot: string, fileName: string): Promise<string | null> {
+  const repoStatePath = path.join(repoRoot, REPO_STATE_DIR, fileName);
+  if (await pathExists(repoStatePath)) {
+    return repoStatePath;
+  }
+
+  const legacyPath = path.join(repoRoot, fileName);
+  if (await pathExists(legacyPath)) {
+    return legacyPath;
+  }
+
+  return null;
+}
+
+export async function initializeRepoState(repoRoot: string, repoName: string): Promise<string[]> {
+  const targetDir = path.join(repoRoot, REPO_STATE_DIR);
+  await fs.mkdir(targetDir, { recursive: true });
+
+  const writtenPaths: string[] = [];
+  for (const [fileName, template] of Object.entries(repoStateTemplates(repoName))) {
+    const targetPath = path.join(targetDir, fileName);
+    if (await pathExists(targetPath)) {
+      continue;
+    }
+
+    await fs.writeFile(targetPath, template, "utf8");
+    writtenPaths.push(targetPath);
+  }
+
+  return writtenPaths;
+}
+
+function repoStateTemplates(repoName: string): Record<string, string> {
+  return {
+    "README.md": [
+      `# ${repoName}`,
+      "",
+      "This directory contains the repo-local OpenReactor state for this product.",
+      "",
+      "OpenReactor's shared engine lives outside this repo-local state. What belongs here is the product-specific material that future issue agents should inherit:",
+      "",
+      "- what this repo is for",
+      "- what counts as a good change",
+      "- what to avoid",
+      "- roadmap direction",
+      "- durable memory from past work",
+      "",
+      "Treat these files as the product steering layer for this repository."
+    ].join("\n") + "\n",
+    "PRODUCT_SPEC.md": [
+      `# ${repoName} Product Spec`,
+      "",
+      "## Product summary",
+      "",
+      "Describe what this repository's product is, who it is for, and what the main user-facing surfaces are.",
+      "",
+      "## Core workflows",
+      "",
+      "- List the main user journeys.",
+      "- Note which flows are highest sensitivity.",
+      "",
+      "## Current constraints",
+      "",
+      "- Document any technical or product constraints that issue agents should respect."
+    ].join("\n") + "\n",
+    "PRODUCT_CONSTITUTION.md": [
+      "# Product Constitution",
+      "",
+      "## Mission",
+      "",
+      "State what this product is meant to optimize for.",
+      "",
+      "## Standing rules",
+      "",
+      "- List the durable product rules agents should treat as binding.",
+      "- Note what kinds of requests should be rejected.",
+      "- Note which surfaces are high-sensitivity.",
+      "",
+      "## Human handoff rules",
+      "",
+      "- Document what should happen when a maintainer-only step is required."
+    ].join("\n") + "\n",
+    "ROADMAP.md": [
+      "# Roadmap",
+      "",
+      "## Near-term priorities",
+      "",
+      "- Add the current priorities for this repo.",
+      "",
+      "## Not now",
+      "",
+      "- Add ideas that are explicitly out of scope for the current stage."
+    ].join("\n") + "\n",
+    "MEMORY.md": [
+      "# Memory",
+      "",
+      "Record durable product and workflow learnings here.",
+      "",
+      "## Decisions",
+      "",
+      "- Add dated decisions with a short reason so future agents inherit them."
+    ].join("\n") + "\n"
+  };
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/reactor/runner.ts
+++ b/reactor/runner.ts
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import type { OrchestratorConfig } from "./config";
 import type { GitHubIssue, GitHubIssueComment } from "./github";
+import { resolveRepoDocumentationPaths } from "./repo-state";
 import {
   DEFAULT_AGENT_TOOL,
   describeAgentToolsForPrompt,
@@ -223,6 +224,7 @@ export async function writeIssueContext(
   const maintainerSteering = getMaintainerSteeringSignal(config, issue);
   const trustedSubmitter = getTrustedSubmitterSignal(config, issue);
   const referenceImages = await prepareRunReferenceImages(issue, paths, discussionComments);
+  const repoDocs = await resolveRepoDocumentationPaths(paths.worktreePath);
 
   const content = [
     "# Issue Context",
@@ -285,13 +287,13 @@ export async function writeIssueContext(
     "",
     "## Product Docs To Read",
     "",
-    "- PRODUCT_SPEC.md",
+    `- ${relativeFromWorktree(paths, repoDocs.productSpec)}`,
     "- CONSTITUTION.md",
-    "- PRODUCT_CONSTITUTION.md",
+    `- ${relativeFromWorktree(paths, repoDocs.productConstitution)}`,
     "- OPENREACTOR_WORKFLOW.md",
-    "- ROADMAP.md",
-    "- MEMORY.md",
-    "- README.md"
+    `- ${relativeFromWorktree(paths, repoDocs.roadmap)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.memory)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.readme)}`
   ].filter(Boolean).join("\n");
 
   await fs.mkdir(paths.runDir, { recursive: true });
@@ -473,7 +475,7 @@ async function spawnCodexIssueAgent(input: {
   const resultPath = path.join(paths.runDir, `iteration-${iteration}.result.json`);
   const logPath = path.join(paths.runDir, `iteration-${iteration}.log`);
   const promptPath = path.join(paths.runDir, `iteration-${iteration}.prompt.md`);
-  const prompt = buildAgentPrompt(config, issue, paths, iteration, "spawn_codex_issue_agent");
+  const prompt = await buildAgentPrompt(config, issue, paths, iteration, "spawn_codex_issue_agent");
 
   await fs.writeFile(promptPath, prompt, "utf8");
 
@@ -570,7 +572,7 @@ async function spawnCodexPlannerAgent(input: {
   const resultPath = path.join(paths.runDir, `iteration-${iteration}.result.json`);
   const logPath = path.join(paths.runDir, `iteration-${iteration}.log`);
   const promptPath = path.join(paths.runDir, `iteration-${iteration}.prompt.md`);
-  const prompt = buildAgentPrompt(config, issue, paths, iteration, "spawn_codex_planner_agent");
+  const prompt = await buildAgentPrompt(config, issue, paths, iteration, "spawn_codex_planner_agent");
 
   await fs.writeFile(promptPath, prompt, "utf8");
 
@@ -661,7 +663,7 @@ async function spawnClaudeUiIssueAgent(input: {
   const resultPath = path.join(paths.runDir, `iteration-${iteration}.result.json`);
   const logPath = path.join(paths.runDir, `iteration-${iteration}.log`);
   const promptPath = path.join(paths.runDir, `iteration-${iteration}.prompt.md`);
-  const prompt = buildAgentPrompt(config, issue, paths, iteration, "spawn_claude_ui_agent");
+  const prompt = await buildAgentPrompt(config, issue, paths, iteration, "spawn_claude_ui_agent");
   const schema = await fs.readFile(schemaPath, "utf8");
 
   await fs.writeFile(promptPath, prompt, "utf8");
@@ -746,7 +748,7 @@ export async function runIssueTriage(input: {
 }): Promise<{ result: TriageResult | null; exitCode: number | null; execution: ExecutionMetadata }> {
   const { config, issue, paths, githubToken } = input;
   const schemaPath = path.join(config.repoRoot, "reactor", "triage-result.schema.json");
-  const prompt = buildTriagePrompt(config, issue, input.comments ?? []);
+  const prompt = await buildTriagePrompt(config, issue, paths, input.comments ?? []);
   const referenceImages = await prepareRunReferenceImages(issue, paths, input.comments ?? []);
 
   await fs.mkdir(paths.runDir, { recursive: true });
@@ -841,16 +843,17 @@ export async function finalizeIssueAgentRun(input: {
   };
 }
 
-function buildAgentPrompt(
+async function buildAgentPrompt(
   config: OrchestratorConfig,
   issue: GitHubIssue,
   paths: IssueRuntimePaths,
   iteration: number,
   agentTool: AgentToolName
-): string {
+): Promise<string> {
   const tool = getAgentTool(agentTool);
   const maintainerSteering = getMaintainerSteeringSignal(config, issue);
   const trustedSubmitter = getTrustedSubmitterSignal(config, issue);
+  const repoDocs = await resolveRepoDocumentationPaths(paths.worktreePath);
   const extraFiles =
     agentTool === "spawn_claude_ui_agent"
       ? ["- prompts/ui-agent.md"]
@@ -880,11 +883,15 @@ function buildAgentPrompt(
     `You are OpenReactor's autonomous issue agent for GitHub issue #${issue.number}.`,
     "",
     "Read these files before doing anything else:",
-    "- UI_SYSTEM.md",
+    ...(repoDocs.uiSystem ? [`- ${relativeFromWorktree(paths, repoDocs.uiSystem)}`] : []),
     "- prompts/product-context.md",
     "- prompts/issue-agent.md",
     "- prompts/quality-gates.md",
-    "- PRODUCT_CONSTITUTION.md",
+    `- ${relativeFromWorktree(paths, repoDocs.productSpec)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.productConstitution)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.roadmap)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.memory)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.readme)}`,
     "- OPENREACTOR_WORKFLOW.md",
     ...extraFiles,
     `- ${relativeFromWorktree(paths, paths.contextPath)}`,
@@ -949,13 +956,15 @@ function buildAgentPrompt(
   ].join("\n");
 }
 
-function buildTriagePrompt(
+async function buildTriagePrompt(
   config: OrchestratorConfig,
   issue: GitHubIssue,
+  paths: IssueRuntimePaths,
   comments: GitHubIssueComment[]
-): string {
+): Promise<string> {
   const maintainerSteering = getMaintainerSteeringSignal(config, issue);
   const trustedSubmitter = getTrustedSubmitterSignal(config, issue);
+  const repoDocs = await resolveRepoDocumentationPaths(paths.worktreePath);
   const labels = issue.labels.map((label) => label.name).filter(Boolean).join(", ") || "_None_";
   return [
     `You are OpenReactor's lightweight issue triage agent for GitHub issue #${issue.number}.`,
@@ -965,9 +974,12 @@ function buildTriagePrompt(
     "- prompts/product-context.md",
     "- prompts/issue-agent.md",
     "- CONSTITUTION.md",
-    "- PRODUCT_CONSTITUTION.md",
+    `- ${relativeFromWorktree(paths, repoDocs.productSpec)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.productConstitution)}`,
     "- OPENREACTOR_WORKFLOW.md",
-    "- ROADMAP.md",
+    `- ${relativeFromWorktree(paths, repoDocs.roadmap)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.memory)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.readme)}`,
     "",
     "Issue context:",
     `- Issue: #${issue.number}`,

--- a/reactor/tool.ts
+++ b/reactor/tool.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import { loadConfig } from "./config";
 import { buildExecutionFooter, renderBodyWithExecutionFooter } from "./execution-footer";
+import { initializeRepoState, REPO_STATE_DIR } from "./repo-state";
 
 const execFileAsync = promisify(execFile);
 
@@ -27,6 +28,11 @@ async function main(): Promise<void> {
 
   if (command === "coauthor-trailer") {
     await printCoauthorTrailer(rest);
+    return;
+  }
+
+  if (command === "init-repo-state") {
+    await initRepoState(rest);
     return;
   }
 
@@ -219,6 +225,26 @@ async function printCoauthorTrailer(args: string[]): Promise<void> {
   console.log(`Co-authored-by: ${displayName} <${email}>`);
 }
 
+async function initRepoState(args: string[]): Promise<void> {
+  const cwd = optionalStringArg(args, "--cwd") || process.cwd();
+  const explicitName = optionalStringArg(args, "--repo-name");
+  const repoName = explicitName || inferRepoDisplayName(cwd);
+  const writtenPaths = await initializeRepoState(cwd, repoName);
+
+  console.log(
+    JSON.stringify(
+      {
+        repoRoot: cwd,
+        repoStateDir: path.join(cwd, REPO_STATE_DIR),
+        repoName,
+        created: writtenPaths
+      },
+      null,
+      2
+    )
+  );
+}
+
 async function resolvePullRequestNumber(
   owner: string,
   repo: string,
@@ -380,6 +406,23 @@ function hasFlag(args: string[], name: string): boolean {
   return args.includes(name);
 }
 
+function inferRepoDisplayName(repoRoot: string): string {
+  try {
+    const raw = execFileSync("git", ["-C", repoRoot, "remote", "get-url", "origin"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    }).trim();
+    const match = raw.match(/github\.com[:/](.+?)\/(.+?)(?:\.git)?$/);
+    if (match?.[2]) {
+      return match[2];
+    }
+  } catch {
+    // Fall through to basename.
+  }
+
+  return path.basename(repoRoot);
+}
+
 async function fetchGitHubUser(
   username: string,
   token: string
@@ -426,11 +469,13 @@ function printHelp(): void {
       "  ensure-plan --issue <number> --title <title> --branch <branch> [--run-dir <dir>]",
       "  ensure-pr --issue <number> --branch <branch> --title <title> --body-file <file> [--base main] [--cwd <dir>] [--merge-method squash] [--no-auto-merge]",
       "  coauthor-trailer --username <github-login>",
+      "  init-repo-state [--cwd <dir>] [--repo-name <name>]",
       "",
       "Notes:",
       "  ensure-pr pushes over HTTPS using GITHUB_TOKEN/GH_TOKEN, so reactor runs publish branches as the GitHub App rather than the machine's SSH identity.",
       "  Auto-merge is enabled by default. Pass --no-auto-merge when the PR should wait for human or manual review.",
-      "  coauthor-trailer resolves a GitHub login to a GitHub-recognized Co-authored-by trailer using the account's user id."
+      "  coauthor-trailer resolves a GitHub login to a GitHub-recognized Co-authored-by trailer using the account's user id.",
+      "  init-repo-state creates the committed repo-local product steering files under .openreactor/repo/."
     ].join("\n")
   );
 }


### PR DESCRIPTION
## Summary
- add a committed repo-local `.openreactor/repo/` steering layer for product docs and memory
- teach the reactor to prefer those repo-local docs over the legacy top-level product files
- add a bootstrap tool to initialize that repo-local state in a target repository

## Why This Approach
OpenReactor cannot become a reusable multi-repo system if product steering only lives in the engine repo. This starts the split between shared engine code and per-repo product memory without trying to solve hosted deployment yet.

## Key Changes
- new `reactor/repo-state.ts` helper for repo-local doc resolution and scaffolding
- `reactor:tool init-repo-state` to generate `.openreactor/repo/README.md`, `PRODUCT_SPEC.md`, `PRODUCT_CONSTITUTION.md`, `ROADMAP.md`, and `MEMORY.md`
- runner/context/prompt resolution now prefers `.openreactor/repo/` docs when present
- docs and prompts updated to reflect the repo-local state model

## Verification
- `bun run check`
- temp repo smoke test for `bun run reactor:tool init-repo-state --repo-name sample-product`
