### PR TITLE
Add automatic managed-repo bootstrap flow

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -205,3 +205,64 @@
   Reason: OpenReactor should eventually manage many repos, and each repo needs
   its own product memory, roadmap, and constitution without having to vendor
   the whole OpenReactor engine into that repo.
+- Decision: the intended onboarding flow for managed repos should infer a
+  first-pass product description from the repo README and existing GitHub
+  issues, then open a bootstrap PR creating `.openreactor/repo/`.
+  Reason: end users should not need to hand-author every OpenReactor steering
+  file from scratch before the system can begin, and most early product
+  context already exists in the repo README or a PRD-style issue.
+
+- Decision: the repo-state bootstrap helper should seed its first-pass files
+  from the repo README and the existing GitHub issues when those inputs are
+  available.
+  Reason: even a lightweight inferred seed is better than starting from blank
+  product steering files during onboarding.
+
+- Decision: managed repos should not need a separate onboarding wizard after
+  GitHub App install. The local OpenReactor runtime should infer first-pass
+  repo state automatically and open a bootstrap PR the first time it sees a
+  repo without committed `.openreactor/repo/` files.
+  Reason: the desired product shape is “install the app, start the local
+  runtime, and let OpenReactor begin,” not a manual setup flow.
+
+- Decision: legacy repos that already have the older top-level product docs
+  should keep running while the bootstrap PR is open, but repos without either
+  repo-local state or legacy top-level docs should gate on the bootstrap first.
+  Reason: this avoids disrupting the existing OpenReactor repo while still
+  making brand-new managed repos initialize themselves before autonomous issue
+  work begins.
+
+- Decision: the shared OpenReactor engine should be able to manage another
+  locally cloned repo without vendoring the runtime into that target repo.
+  Reason: the near-term scaling step is from one repo to two, with both still
+  running on the same machine, so engine-root and managed-repo-root need to be
+  distinct concepts in the runtime.
+
+- Decision: managed-repo privilege should be inferred from GitHub itself.
+  Repo owners should have the highest steering authority, maintainers and
+  contributors should count as privileged steering entities, and ordinary issue
+  authors should still pass through the normal governance filters.
+  Reason: GitHub is the natural source of truth for repository trust and
+  authorship in the default OpenReactor deployment model.
+
+- Decision: use GitHub's native `author_association` field as the first runtime
+  trust signal for repo-owner and contributor privilege on issues.
+  Reason: this lets OpenReactor infer owner/contributor privilege directly from
+  the repository instead of relying only on OpenReactor-specific labels or
+  body fields.
+
+- Decision: OpenReactor should eventually author commits as the GitHub App or
+  another explicit OpenReactor machine identity, not as the maintainer's local
+  git identity.
+  Reason: the current system already pushes branches using the GitHub token,
+  but commit authorship still follows the local git config unless the runtime
+  sets it explicitly, which is not the desired long-term behavior for managed
+  repos.
+
+- Decision: configure each issue worktree with an explicit OpenReactor git
+  author identity and pass the same identity into spawned agents through
+  `GIT_AUTHOR_*` and `GIT_COMMITTER_*`.
+  Reason: push authentication and commit authorship are different concerns.
+  OpenReactor already publishes branches through the GitHub token path, but it
+  also needs explicit git author settings so commits do not inherit the local
+  machine user's identity.

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -110,6 +110,49 @@ memory should live for a managed repository. The current committed layout is:
 When those files exist, issue agents and triage should prefer them over the
 legacy top-level product docs.
 
+For managed repos, initialization should prefer inference over blank setup:
+
+- read the repo README
+- read the initial GitHub issues, especially a PRD-style issue if one exists
+- infer a first-pass product description and product constitution from that
+  material
+- open a bootstrap PR that creates `.openreactor/repo/`
+
+The current bootstrap helper seeds that first pass from the repo README and the
+existing GitHub issues when those inputs are available.
+
+The current local deployment model is intentionally simple:
+
+- clone the target repo onto the machine that already runs OpenReactor
+- point the local OpenReactor engine at that clone
+- let the reactor open the bootstrap PR automatically if `.openreactor/repo/`
+  does not already exist on `main`
+- begin normal issue handling only after that repo-local steering state exists
+
+Legacy repos that already have the older top-level product docs may continue to
+run while the bootstrap PR is open. Repos that do not have either repo-local
+state or the legacy top-level docs should wait for the bootstrap first.
+
+This avoids a separate onboarding wizard while still keeping the runtime local
+and the per-repo steering state committed inside the managed repository.
+
+OpenReactor's default external UX should be GitHub-native. It should not
+assume that every managed repo also exposes a public intake website.
+
+Privilege should also be inferred from GitHub first:
+
+- repo owners have the strongest steering authority
+- maintainers and contributors count as privileged steering entities
+- ordinary issue authors still go through the normal governance filters
+
+The first runtime implementation of that trust model should come from GitHub's
+native `author_association` on issues and comments rather than from
+OpenReactor-only metadata.
+
+OpenReactor should not inherit a human maintainer's local git identity for
+authored commits. Even when the runtime is operating on a maintainer-owned
+machine, issue worktrees should be configured with an explicit OpenReactor
+machine identity so commit authorship is visibly automated.
 ## OpenReactor proposals
 
 If an issue is labeled `openreactor-core`, agents should treat it as an

--- a/README.md
+++ b/README.md
@@ -150,12 +150,56 @@ When those files exist, the reactor prefers them over the legacy top-level
 product docs. This lets a target repo keep its own product direction and memory
 without needing to vendor the whole OpenReactor runtime into the repo.
 
-Bootstrap that repo-local steering layer with:
+Bootstrap that repo-local steering layer manually with:
 
 ```bash
 bun run reactor:tool init-repo-state
 ```
 
+That bootstrap now tries to seed the repo-local files from:
+
+- the repo README, if one exists
+- existing GitHub issues, especially PRD-like setup issues
+
+The intended managed-repo flow is:
+
+1. user creates a repo and writes an initial PRD, usually as a README or an
+   initial GitHub issue,
+2. user installs the OpenReactor GitHub App on that repo,
+3. the local OpenReactor runtime starts against a clone of that repo,
+4. OpenReactor infers a first-pass product description from the repo README and
+   the existing GitHub issue discussion,
+5. OpenReactor automatically opens a bootstrap PR creating `.openreactor/repo/`
+   from that material,
+6. once that repo-local state exists on `main`, OpenReactor proceeds with the
+   normal issue loop.
+
+For older repos that already have the legacy top-level product docs
+(`README.md`, `PRODUCT_SPEC.md`, `PRODUCT_CONSTITUTION.md`, `ROADMAP.md`,
+`MEMORY.md`), OpenReactor can keep operating while that bootstrap PR is still
+open. Brand-new repos without those docs are gated on the bootstrap first.
+
+This is intentionally different from the public OpenReactor website. The
+website's public feature form is a demo/product surface for OpenReactor
+itself. The default product shape for other repos is GitHub-native: repo
+owners and contributors work through GitHub issues, and OpenReactor consumes
+that issue stream directly.
+
+The intended privilege model is also GitHub-native:
+
+- repository owners should have the highest steering authority
+- maintainers/contributors should count as privileged steering entities
+- random public issue authors should still go through the normal product
+  governance filters
+
+The first runtime implementation of that model now uses GitHub's native
+`author_association` field on issues, so owners and contributors are detected
+from the repository itself rather than only from OpenReactor-managed labels.
+
+OpenReactor should also use its own git identity for authored commits. Branch
+publication already goes through the GitHub token/app path; issue worktrees now
+also get an explicit OpenReactor author identity so commits do not inherit the
+local maintainer's git config by accident.
 ## Running The Reactor
 
 The repository includes the machine-local orchestration loop under
@@ -166,6 +210,22 @@ for the Pages site:
 
 ```bash
 bun run reactor
+```
+
+To run the same local OpenReactor engine against a different cloned repo,
+point the managed-repo root at that checkout and invoke the engine from this
+repo:
+
+```bash
+OPENREACTOR_MANAGED_REPO_ROOT=/home/ray/projects/some-other-repo \
+  bun /home/ray/projects/openreactor/reactor/index.ts
+```
+
+The same pattern works for the watchdog:
+
+```bash
+OPENREACTOR_MANAGED_REPO_ROOT=/home/ray/projects/some-other-repo \
+  bash /home/ray/projects/openreactor/scripts/watchdog-service.sh
 ```
 
 One-pass dry operation:

--- a/ops/reactor.env.example
+++ b/ops/reactor.env.example
@@ -3,6 +3,11 @@
 #
 # Use a single line for GITHUB_APP_PRIVATE_KEY with literal \n escapes.
 
+# Optional when the OpenReactor engine is managing a different local clone.
+# Leave both unset when managing this repo directly.
+# OPENREACTOR_ENGINE_ROOT=/home/ray/projects/openreactor
+# OPENREACTOR_MANAGED_REPO_ROOT=/home/ray/projects/some-other-repo
+
 GITHUB_OWNER=rayzhudev
 GITHUB_REPO=openreactor
 GITHUB_APP_ID=

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -4,16 +4,16 @@ You are the autonomous agent for one GitHub issue.
 
 ## What You Must Do First
 
-1. Read `prompts/product-context.md`.
-2. Read `prompts/quality-gates.md`.
-3. Read `CONSTITUTION.md`.
+1. Read the OpenReactor engine's `product-context.md` prompt file provided in your run instructions.
+2. Read the OpenReactor engine's `quality-gates.md` prompt file provided in your run instructions.
+3. Read the OpenReactor engine's `CONSTITUTION.md`.
 4. Read the repo-local product constitution under `.openreactor/repo/` when present, otherwise `PRODUCT_CONSTITUTION.md`, and read `OPENREACTOR_WORKFLOW.md`.
 5. If you touch UI, read the repo-local UI system file when present, otherwise `UI_SYSTEM.md`, before editing.
 6. Read the issue context file provided in the run directory.
 7. If the issue context lists reference images, inspect them before making implementation decisions.
 8. Read `progress.md` if it already exists.
 9. If `plan.json` exists, use it. If not, create it before coding.
-10. Prefer the repo-local helper commands when they make the workflow more reliable.
+10. Prefer the OpenReactor helper command exposed at `$OPENREACTOR_ENGINE_TOOL` when it makes the workflow more reliable.
 
 ## Your Authority
 
@@ -113,7 +113,7 @@ single markdown source of truth for remaining work.
 You can restore or initialize the plan scaffold with:
 
 ```bash
-bun run reactor:tool ensure-plan --issue "$OPENREACTOR_ISSUE_NUMBER" --title "..." --branch "$OPENREACTOR_BRANCH_NAME"
+bun "$OPENREACTOR_ENGINE_TOOL" ensure-plan --issue "$OPENREACTOR_ISSUE_NUMBER" --title "..." --branch "$OPENREACTOR_BRANCH_NAME"
 ```
 
 `progress.md` is append-only. Record:
@@ -180,7 +180,7 @@ If blocked on a human-only step:
 
 - push the branch if the partial work is useful
 - open or update a PR if reviewable
-- use `bun run reactor:tool ensure-pr ... --no-auto-merge` for that PR
+- use `bun "$OPENREACTOR_ENGINE_TOOL" ensure-pr ... --no-auto-merge` for that PR
 - leave exact human continuation instructions in the issue comment, PR body, `plan.json`, and `progress.md`
 - set `humanHandoff.required` to `true` with exact continuation instructions
 - return `retry` unless the remaining work is explicitly outside the accepted scope
@@ -190,7 +190,7 @@ If blocked on a human-only step:
 Use this to make PR creation idempotent:
 
 ```bash
-bun run reactor:tool ensure-pr --issue "$OPENREACTOR_ISSUE_NUMBER" --branch "$OPENREACTOR_BRANCH_NAME" --title "..." --body-file ./path/to/pr-body.md
+bun "$OPENREACTOR_ENGINE_TOOL" ensure-pr --issue "$OPENREACTOR_ISSUE_NUMBER" --branch "$OPENREACTOR_BRANCH_NAME" --title "..." --body-file ./path/to/pr-body.md
 ```
 
 When writing `pr-body.md`, prefer a structure like:
@@ -225,7 +225,7 @@ context exists.
 If the PR needs human intervention or explicit manual review, opt out:
 
 ```bash
-bun run reactor:tool ensure-pr --issue "$OPENREACTOR_ISSUE_NUMBER" --branch "$OPENREACTOR_BRANCH_NAME" --title "..." --body-file ./path/to/pr-body.md --no-auto-merge
+bun "$OPENREACTOR_ENGINE_TOOL" ensure-pr --issue "$OPENREACTOR_ISSUE_NUMBER" --branch "$OPENREACTOR_BRANCH_NAME" --title "..." --body-file ./path/to/pr-body.md --no-auto-merge
 ```
 
 Do not use raw `git push origin ...` for the final publication step. The helper above pushes with the GitHub App token so the remote write is clearly automated.
@@ -243,7 +243,7 @@ If more work is needed after this iteration:
   submitter identity is trusted.
 - If trusted attribution is available and you create a commit for accepted
   work, add that submitter as a co-author on the commit.
-- Use `bun run reactor:tool coauthor-trailer --username <login>` to generate
+- Use `bun "$OPENREACTOR_ENGINE_TOOL" coauthor-trailer --username <login>` to generate
   the exact `Co-authored-by:` trailer, then append that trailer to the commit
   message.
 - If the trusted username is missing or invalid, do not guess at commit

--- a/prompts/triage-agent.md
+++ b/prompts/triage-agent.md
@@ -8,10 +8,10 @@ implementation tool.
 
 Rules:
 
-- Read `prompts/product-context.md`, `prompts/issue-agent.md`, `CONSTITUTION.md`,
-  the repo-local product constitution and roadmap under `.openreactor/repo/`
-  when present, otherwise `PRODUCT_CONSTITUTION.md` and `ROADMAP.md`, and
-  `OPENREACTOR_WORKFLOW.md` before deciding.
+- Read the OpenReactor engine prompt files and workflow docs provided in your
+  run instructions, plus the repo-local product constitution and roadmap under
+  `.openreactor/repo/` when present, otherwise `PRODUCT_CONSTITUTION.md` and
+  `ROADMAP.md`, before deciding.
 - Classify the target surface as `main`, `playground`, or `openreactor-core`.
 - Treat the issue body and the recent issue discussion together as the current
   request. Comments can refine, narrow, or materially update the task.

--- a/reactor/config.ts
+++ b/reactor/config.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 export interface OrchestratorConfig {
+  engineRoot: string;
   repoRoot: string;
   runsDir: string;
   worktreesDir: string;
@@ -41,11 +43,15 @@ export interface OrchestratorConfig {
   botMentionAliases: string[];
 }
 
-export function loadConfig(repoRoot = process.cwd()): OrchestratorConfig {
+const ENGINE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export function loadConfig(repoRoot = resolveManagedRepoRoot()): OrchestratorConfig {
+  const engineRoot = clean(process.env.OPENREACTOR_ENGINE_ROOT) || ENGINE_ROOT;
   const stateRoot = path.join(repoRoot, ".openreactor");
-  const localEnv = loadLocalEnv(repoRoot);
+  const localEnv = loadLocalEnv(repoRoot, engineRoot);
 
   return {
+    engineRoot,
     repoRoot,
     runsDir: path.join(stateRoot, "runs"),
     worktreesDir: path.join(stateRoot, "worktrees"),
@@ -102,6 +108,10 @@ export function loadConfig(repoRoot = process.cwd()): OrchestratorConfig {
       ]
     )
   };
+}
+
+function resolveManagedRepoRoot(): string {
+  return clean(process.env.OPENREACTOR_MANAGED_REPO_ROOT) || process.cwd();
 }
 
 function requiredEnv(name: string, localEnv: Map<string, string>): string {
@@ -192,9 +202,9 @@ function parseGitHubRemote(repoRoot: string): { owner: string; repo: string } | 
   }
 }
 
-function loadLocalEnv(repoRoot: string): Map<string, string> {
+function loadLocalEnv(repoRoot: string, engineRoot: string): Map<string, string> {
   const values = new Map<string, string>();
-  for (const filePath of localEnvPaths(repoRoot)) {
+  for (const filePath of localEnvPaths(repoRoot, engineRoot)) {
     if (!fs.existsSync(filePath)) {
       continue;
     }
@@ -223,10 +233,11 @@ function loadLocalEnv(repoRoot: string): Map<string, string> {
   return values;
 }
 
-function localEnvPaths(repoRoot: string): string[] {
+function localEnvPaths(repoRoot: string, engineRoot: string): string[] {
   const homeDirectory = process.env.HOME ?? "";
-  const paths = [".dev.vars", ".env.local", ".env"].map((fileName) =>
-    path.join(repoRoot, fileName)
+  const repoRoots = Array.from(new Set([repoRoot, engineRoot].filter(Boolean)));
+  const paths = repoRoots.flatMap((root) =>
+    [".dev.vars", ".env.local", ".env"].map((fileName) => path.join(root, fileName))
   );
 
   if (homeDirectory) {

--- a/reactor/github.ts
+++ b/reactor/github.ts
@@ -261,6 +261,23 @@ export class GitHubClient {
     );
   }
 
+  async createPullRequest(input: {
+    title: string;
+    body: string;
+    head: string;
+    base: string;
+  }): Promise<GitHubPullRequest> {
+    return this.request<GitHubPullRequest>(`/repos/${this.config.owner}/${this.config.repo}/pulls`, {
+      method: "POST",
+      body: JSON.stringify({
+        title: input.title,
+        body: input.body,
+        head: input.head,
+        base: input.base
+      })
+    });
+  }
+
   async updatePullRequest(
     pullRequestNumber: number,
     input: {
@@ -345,6 +362,26 @@ export class GitHubClient {
       ].join("\n"),
       {
         pullRequestId: pullRequest.id
+      }
+    );
+  }
+
+  async enablePullRequestAutoMerge(
+    pullRequestNumber: number,
+    mergeMethod: "MERGE" | "REBASE" | "SQUASH" = "SQUASH"
+  ): Promise<void> {
+    const pullRequest = await this.getPullRequestGraphNode(pullRequestNumber);
+    await this.graphqlRequest(
+      [
+        "mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {",
+        "  enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: $mergeMethod }) {",
+        "    clientMutationId",
+        "  }",
+        "}"
+      ].join("\n"),
+      {
+        pullRequestId: pullRequest.id,
+        mergeMethod
       }
     );
   }

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -1,4 +1,8 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import process from "node:process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { loadConfig, type OrchestratorConfig } from "./config";
 import {
   DEFAULT_AGENT_TOOL,
@@ -35,9 +39,20 @@ import {
   type RunRecord,
   type TriageResult
 } from "./runner";
+import {
+  ensureRepoRuntimeGitignore,
+  hasRepoStateFiles,
+  initializeRepoState,
+  REPO_STATE_DIR,
+  type RepoStateSeedIssue
+} from "./repo-state";
+
+const execFileAsync = promisify(execFile);
 
 const STATUS_COMMENT_MARKER = "<!-- openreactor:status -->";
 const DECISION_COMMENT_MARKER = "<!-- openreactor:decision -->";
+const BOOTSTRAP_BRANCH_NAME = "openreactor/bootstrap-repo-state";
+const BOOTSTRAP_PR_TITLE = "Bootstrap OpenReactor repo state";
 const FEEDBACK_BANK_LABEL = "feedback-bank";
 const NEEDS_REFINEMENT_LABEL = "needs-refinement";
 const OPENREACTOR_CORE_LABEL = "openreactor-core";
@@ -179,6 +194,11 @@ class Reactor {
   }
 
   private async tick(): Promise<void> {
+    if (!(await this.ensureRepoStateBootstrap())) {
+      await this.updateLiveStatus();
+      return;
+    }
+
     this.blockedDependencyCache.clear();
     await this.reconcileStaleActiveRuns();
 
@@ -257,6 +277,105 @@ class Reactor {
     }
 
     await this.updateLiveStatus();
+  }
+
+  private async ensureRepoStateBootstrap(): Promise<boolean> {
+    if (await hasRepoStateFiles(this.config.repoRoot)) {
+      return true;
+    }
+
+    await refreshRemoteMain(this.config.repoRoot);
+    if (await hasRepoStateOnRef(this.config.repoRoot, "origin/main")) {
+      return true;
+    }
+
+    const legacyDocsReady = await hasLegacyRepoProductDocs(this.config.repoRoot);
+
+    const existingPullRequest = await this.github.findOpenPullRequestByBranch(BOOTSTRAP_BRANCH_NAME);
+    if (existingPullRequest) {
+      return legacyDocsReady;
+    }
+
+    if (this.dryRun) {
+      console.log(
+        JSON.stringify(
+          {
+            mode: "dry-run",
+            bootstrapRequired: !legacyDocsReady,
+            bootstrapRecommended: legacyDocsReady,
+            repoRoot: this.config.repoRoot,
+            branchName: BOOTSTRAP_BRANCH_NAME
+          },
+          null,
+          2
+        )
+      );
+      return legacyDocsReady;
+    }
+
+    const bootstrapWorktreePath = path.join(this.config.worktreesDir, "bootstrap-repo-state");
+    await recreateBootstrapWorktree(this.config.repoRoot, bootstrapWorktreePath, BOOTSTRAP_BRANCH_NAME);
+    const readmeBody = await readRepoReadme(this.config.repoRoot);
+    const issues = await this.loadBootstrapSeedIssues();
+    await initializeRepoState(bootstrapWorktreePath, this.config.repo, {
+      readmeBody,
+      issues
+    });
+    await ensureRepoRuntimeGitignore(bootstrapWorktreePath);
+
+    if (!(await hasGitChanges(bootstrapWorktreePath))) {
+      return false;
+    }
+
+    await runGit(bootstrapWorktreePath, ["add", "-A", ".gitignore", REPO_STATE_DIR]);
+    await runGit(bootstrapWorktreePath, [
+      "commit",
+      "-m",
+      "Bootstrap OpenReactor repo state"
+    ]);
+
+    const accessToken = await this.github.getAgentAccessToken();
+    await pushBranchWithToken({
+      cwd: bootstrapWorktreePath,
+      owner: this.config.owner,
+      repo: this.config.repo,
+      branchName: BOOTSTRAP_BRANCH_NAME,
+      token: accessToken
+    });
+
+    const pullRequest = await this.github.createPullRequest({
+      title: BOOTSTRAP_PR_TITLE,
+      head: BOOTSTRAP_BRANCH_NAME,
+      base: "main",
+      body: buildBootstrapPullRequestBody({
+        repoName: this.config.repo,
+        readmeDetected: Boolean(readmeBody.trim()),
+        issueCount: issues.length
+      })
+    });
+
+    try {
+      await this.github.enablePullRequestAutoMerge(pullRequest.number, "SQUASH");
+    } catch (error) {
+      console.warn(
+        `Unable to enable auto-merge for bootstrap PR #${pullRequest.number}.`,
+        error
+      );
+    }
+
+    return legacyDocsReady;
+  }
+
+  private async loadBootstrapSeedIssues(): Promise<RepoStateSeedIssue[]> {
+    const issues = await this.github.listOpenIssues();
+    return issues
+      .filter((issue) => !issue.pull_request)
+      .slice(0, 8)
+      .map((issue) => ({
+        number: issue.number,
+        title: issue.title,
+        body: issue.body
+      }));
   }
 
   private async triageIssue(issue: GitHubIssue): Promise<TriageResult | null> {
@@ -1509,6 +1628,144 @@ function normalizeDecomposedIssueTitle(title: string): string {
   }
 
   return `[Task] ${cleaned}`;
+}
+
+async function readRepoReadme(repoRoot: string): Promise<string> {
+  for (const candidate of ["README.md", "Readme.md", "readme.md"]) {
+    try {
+      return await fs.readFile(path.join(repoRoot, candidate), "utf8");
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return "";
+}
+
+async function hasRepoStateOnRef(repoRoot: string, ref: string): Promise<boolean> {
+  try {
+    await execFileAsync("git", [
+      "-C",
+      repoRoot,
+      "cat-file",
+      "-e",
+      `${ref}:${path.posix.join(".openreactor", "repo", "README.md")}`
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function hasLegacyRepoProductDocs(repoRoot: string): Promise<boolean> {
+  const requiredFiles = [
+    "README.md",
+    "PRODUCT_SPEC.md",
+    "PRODUCT_CONSTITUTION.md",
+    "ROADMAP.md",
+    "MEMORY.md"
+  ];
+
+  const checks = await Promise.all(
+    requiredFiles.map(async (fileName) => {
+      try {
+        await fs.access(path.join(repoRoot, fileName));
+        return true;
+      } catch {
+        return false;
+      }
+    })
+  );
+
+  return checks.every(Boolean);
+}
+
+async function refreshRemoteMain(repoRoot: string): Promise<void> {
+  await execFileAsync("git", ["-C", repoRoot, "fetch", "--prune", "origin", "main"]);
+}
+
+async function recreateBootstrapWorktree(
+  repoRoot: string,
+  worktreePath: string,
+  branchName: string
+): Promise<void> {
+  try {
+    await execFileAsync("git", ["-C", repoRoot, "worktree", "remove", "--force", worktreePath]);
+  } catch {
+    // Ignore missing worktree state.
+  }
+
+  try {
+    await execFileAsync("git", ["-C", repoRoot, "branch", "-D", branchName]);
+  } catch {
+    // Ignore missing branch state.
+  }
+
+  await execFileAsync("git", [
+    "-C",
+    repoRoot,
+    "worktree",
+    "add",
+    "-b",
+    branchName,
+    worktreePath,
+    "origin/main"
+  ]);
+}
+
+async function hasGitChanges(repoRoot: string): Promise<boolean> {
+  const { stdout } = await execFileAsync("git", ["-C", repoRoot, "status", "--short"]);
+  return stdout.trim().length > 0;
+}
+
+async function runGit(repoRoot: string, args: string[]): Promise<void> {
+  await execFileAsync("git", ["-C", repoRoot, ...args]);
+}
+
+async function pushBranchWithToken(input: {
+  cwd: string;
+  owner: string;
+  repo: string;
+  branchName: string;
+  token: string;
+}): Promise<void> {
+  const remoteUrl = `https://github.com/${input.owner}/${input.repo}.git`;
+  const basicAuth = Buffer.from(`x-access-token:${input.token}`, "utf8").toString("base64");
+
+  await execFileAsync("git", [
+    "-C",
+    input.cwd,
+    "-c",
+    `http.https://github.com/.extraheader=AUTHORIZATION: basic ${basicAuth}`,
+    "push",
+    remoteUrl,
+    `HEAD:refs/heads/${input.branchName}`
+  ]);
+}
+
+function buildBootstrapPullRequestBody(input: {
+  repoName: string;
+  readmeDetected: boolean;
+  issueCount: number;
+}): string {
+  return [
+    "## Summary",
+    `Bootstrap repo-local OpenReactor steering files under \`${REPO_STATE_DIR}/\` for ${input.repoName}.`,
+    "",
+    "## Signals Used",
+    `- README detected: ${input.readmeDetected ? "yes" : "no"}`,
+    `- Open issue signals included: ${input.issueCount}`,
+    "",
+    "## Included",
+    "- `.openreactor/repo/README.md`",
+    "- `.openreactor/repo/PRODUCT_SPEC.md`",
+    "- `.openreactor/repo/PRODUCT_CONSTITUTION.md`",
+    "- `.openreactor/repo/ROADMAP.md`",
+    "- `.openreactor/repo/MEMORY.md`",
+    "- `.gitignore` rules so runtime state stays local while repo steering stays committed",
+    "",
+    "This PR was opened automatically because OpenReactor detected that the managed repository did not yet have committed repo-local steering state."
+  ].join("\n");
 }
 
 function ensureParentLinkInDecomposedIssueBody(issue: GitHubIssue, body: string): string {

--- a/reactor/repo-state.ts
+++ b/reactor/repo-state.ts
@@ -2,6 +2,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 export const REPO_STATE_DIR = path.join(".openreactor", "repo");
+export const REPO_RUNTIME_GITIGNORE_RULES = [
+  ".openreactor/*",
+  "!.openreactor/repo/",
+  "!.openreactor/repo/**"
+];
 
 export interface RepoDocumentationPaths {
   readme: string;
@@ -10,6 +15,17 @@ export interface RepoDocumentationPaths {
   roadmap: string;
   memory: string;
   uiSystem: string | null;
+}
+
+export interface RepoStateSeedIssue {
+  number: number;
+  title: string;
+  body: string | null;
+}
+
+export interface RepoStateSeeds {
+  readmeBody?: string | null;
+  issues?: RepoStateSeedIssue[];
 }
 
 export async function resolveRepoDocumentationPaths(repoRoot: string): Promise<RepoDocumentationPaths> {
@@ -46,12 +62,16 @@ async function resolveOptionalRepoDoc(repoRoot: string, fileName: string): Promi
   return null;
 }
 
-export async function initializeRepoState(repoRoot: string, repoName: string): Promise<string[]> {
+export async function initializeRepoState(
+  repoRoot: string,
+  repoName: string,
+  seeds: RepoStateSeeds = {}
+): Promise<string[]> {
   const targetDir = path.join(repoRoot, REPO_STATE_DIR);
   await fs.mkdir(targetDir, { recursive: true });
 
   const writtenPaths: string[] = [];
-  for (const [fileName, template] of Object.entries(repoStateTemplates(repoName))) {
+  for (const [fileName, template] of Object.entries(repoStateTemplates(repoName, seeds))) {
     const targetPath = path.join(targetDir, fileName);
     if (await pathExists(targetPath)) {
       continue;
@@ -64,7 +84,29 @@ export async function initializeRepoState(repoRoot: string, repoName: string): P
   return writtenPaths;
 }
 
-function repoStateTemplates(repoName: string): Record<string, string> {
+export async function hasRepoStateFiles(repoRoot: string): Promise<boolean> {
+  return pathExists(path.join(repoRoot, REPO_STATE_DIR, "README.md"));
+}
+
+export async function ensureRepoRuntimeGitignore(repoRoot: string): Promise<string | null> {
+  const gitignorePath = path.join(repoRoot, ".gitignore");
+  const existing = await readOptionalText(gitignorePath);
+  const current = existing ?? "";
+  const missingRules = REPO_RUNTIME_GITIGNORE_RULES.filter((rule) => !current.includes(rule));
+  if (!missingRules.length) {
+    return null;
+  }
+
+  const next = current.trimEnd();
+  const prefix = next ? `${next}\n\n` : "";
+  await fs.writeFile(gitignorePath, `${prefix}${missingRules.join("\n")}\n`, "utf8");
+  return gitignorePath;
+}
+
+function repoStateTemplates(repoName: string, seeds: RepoStateSeeds): Record<string, string> {
+  const readmeSummary = summarizeReadme(seeds.readmeBody ?? "");
+  const issueSummary = summarizeIssues(seeds.issues ?? []);
+
   return {
     "README.md": [
       `# ${repoName}`,
@@ -79,14 +121,33 @@ function repoStateTemplates(repoName: string): Record<string, string> {
       "- roadmap direction",
       "- durable memory from past work",
       "",
-      "Treat these files as the product steering layer for this repository."
+      "Treat these files as the product steering layer for this repository.",
+      "",
+      "## Bootstrap signals",
+      "",
+      ...(readmeSummary
+        ? [
+            "### README signal",
+            "",
+            readmeSummary
+          ]
+        : ["_No README signal was detected during bootstrap._"]),
+      "",
+      ...(issueSummary
+        ? [
+            "### Issue signal",
+            "",
+            issueSummary
+          ]
+        : ["_No GitHub issue signal was detected during bootstrap._"])
     ].join("\n") + "\n",
     "PRODUCT_SPEC.md": [
       `# ${repoName} Product Spec`,
       "",
       "## Product summary",
       "",
-      "Describe what this repository's product is, who it is for, and what the main user-facing surfaces are.",
+      readmeSummary ||
+        "Describe what this repository's product is, who it is for, and what the main user-facing surfaces are.",
       "",
       "## Core workflows",
       "",
@@ -120,6 +181,14 @@ function repoStateTemplates(repoName: string): Record<string, string> {
       "## Near-term priorities",
       "",
       "- Add the current priorities for this repo.",
+      ...(issueSummary
+        ? [
+            "",
+            "## Signals from existing issues",
+            "",
+            issueSummary
+          ]
+        : []),
       "",
       "## Not now",
       "",
@@ -129,6 +198,14 @@ function repoStateTemplates(repoName: string): Record<string, string> {
       "# Memory",
       "",
       "Record durable product and workflow learnings here.",
+      ...(readmeSummary
+        ? [
+            "",
+            "## Bootstrap context",
+            "",
+            readmeSummary
+          ]
+        : []),
       "",
       "## Decisions",
       "",
@@ -137,11 +214,62 @@ function repoStateTemplates(repoName: string): Record<string, string> {
   };
 }
 
+function summarizeReadme(readmeBody: string): string {
+  const normalized = stripMarkdownNoise(readmeBody)
+    .split(/\n{2,}/)
+    .map((chunk) => chunk.trim())
+    .filter(Boolean)
+    .filter((chunk) => !chunk.startsWith("#"));
+
+  return normalized.slice(0, 2).join("\n\n");
+}
+
+function summarizeIssues(issues: RepoStateSeedIssue[]): string {
+  return issues
+    .slice(0, 5)
+    .map((issue) =>
+      [
+        `- #${issue.number} ${issue.title}`,
+        issue.body
+          ? `  ${truncateInline(stripMarkdownNoise(issue.body), 220)}`
+          : "  _No body provided._"
+      ].join("\n")
+    )
+    .join("\n");
+}
+
+function stripMarkdownNoise(value: string): string {
+  return value
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/!\[[^\]]*]\(([^)]+)\)/g, " ")
+    .replace(/\[([^\]]+)]\(([^)]+)\)/g, "$1")
+    .replace(/\r/g, "")
+    .trim();
+}
+
+function truncateInline(value: string, maxLength: number): string {
+  const singleLine = value.replace(/\s+/g, " ").trim();
+  if (singleLine.length <= maxLength) {
+    return singleLine;
+  }
+
+  return `${singleLine.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
 async function pathExists(filePath: string): Promise<boolean> {
   try {
     await fs.access(filePath);
     return true;
   } catch {
     return false;
+  }
+}
+
+async function readOptionalText(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch {
+    return null;
   }
 }

--- a/reactor/runner.ts
+++ b/reactor/runner.ts
@@ -288,9 +288,9 @@ export async function writeIssueContext(
     "## Product Docs To Read",
     "",
     `- ${relativeFromWorktree(paths, repoDocs.productSpec)}`,
-    "- CONSTITUTION.md",
+    `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "CONSTITUTION.md"))}`,
     `- ${relativeFromWorktree(paths, repoDocs.productConstitution)}`,
-    "- OPENREACTOR_WORKFLOW.md",
+    `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "OPENREACTOR_WORKFLOW.md"))}`,
     `- ${relativeFromWorktree(paths, repoDocs.roadmap)}`,
     `- ${relativeFromWorktree(paths, repoDocs.memory)}`,
     `- ${relativeFromWorktree(paths, repoDocs.readme)}`
@@ -471,7 +471,7 @@ async function spawnCodexIssueAgent(input: {
 }): Promise<ActiveRun> {
   const { config, issue, paths, githubToken } = input;
   const iteration = input.record.iteration + 1;
-  const schemaPath = path.join(config.repoRoot, "reactor", "agent-result.schema.json");
+  const schemaPath = path.join(config.engineRoot, "reactor", "agent-result.schema.json");
   const resultPath = path.join(paths.runDir, `iteration-${iteration}.result.json`);
   const logPath = path.join(paths.runDir, `iteration-${iteration}.log`);
   const promptPath = path.join(paths.runDir, `iteration-${iteration}.prompt.md`);
@@ -497,6 +497,8 @@ async function spawnCodexIssueAgent(input: {
       GITHUB_TOKEN: githubToken,
       OPENREACTOR_REPO_OWNER: config.owner,
       OPENREACTOR_REPO_NAME: config.repo,
+      OPENREACTOR_ENGINE_ROOT: config.engineRoot,
+      OPENREACTOR_ENGINE_TOOL: path.join(config.engineRoot, "reactor", "tool.ts"),
       OPENREACTOR_ISSUE_NUMBER: String(issue.number),
       OPENREACTOR_ISSUE_URL: issue.html_url,
       OPENREACTOR_RUN_DIR: paths.runDir,
@@ -568,7 +570,7 @@ async function spawnCodexPlannerAgent(input: {
 }): Promise<ActiveRun> {
   const { config, issue, paths, githubToken } = input;
   const iteration = input.record.iteration + 1;
-  const schemaPath = path.join(config.repoRoot, "reactor", "agent-result.schema.json");
+  const schemaPath = path.join(config.engineRoot, "reactor", "agent-result.schema.json");
   const resultPath = path.join(paths.runDir, `iteration-${iteration}.result.json`);
   const logPath = path.join(paths.runDir, `iteration-${iteration}.log`);
   const promptPath = path.join(paths.runDir, `iteration-${iteration}.prompt.md`);
@@ -594,6 +596,8 @@ async function spawnCodexPlannerAgent(input: {
       GITHUB_TOKEN: githubToken,
       OPENREACTOR_REPO_OWNER: config.owner,
       OPENREACTOR_REPO_NAME: config.repo,
+      OPENREACTOR_ENGINE_ROOT: config.engineRoot,
+      OPENREACTOR_ENGINE_TOOL: path.join(config.engineRoot, "reactor", "tool.ts"),
       OPENREACTOR_ISSUE_NUMBER: String(issue.number),
       OPENREACTOR_ISSUE_URL: issue.html_url,
       OPENREACTOR_RUN_DIR: paths.runDir,
@@ -659,7 +663,7 @@ async function spawnClaudeUiIssueAgent(input: {
 }): Promise<ActiveRun> {
   const { config, issue, paths, githubToken } = input;
   const iteration = input.record.iteration + 1;
-  const schemaPath = path.join(config.repoRoot, "reactor", "agent-result.schema.json");
+  const schemaPath = path.join(config.engineRoot, "reactor", "agent-result.schema.json");
   const resultPath = path.join(paths.runDir, `iteration-${iteration}.result.json`);
   const logPath = path.join(paths.runDir, `iteration-${iteration}.log`);
   const promptPath = path.join(paths.runDir, `iteration-${iteration}.prompt.md`);
@@ -683,6 +687,8 @@ async function spawnClaudeUiIssueAgent(input: {
       GITHUB_TOKEN: githubToken,
       OPENREACTOR_REPO_OWNER: config.owner,
       OPENREACTOR_REPO_NAME: config.repo,
+      OPENREACTOR_ENGINE_ROOT: config.engineRoot,
+      OPENREACTOR_ENGINE_TOOL: path.join(config.engineRoot, "reactor", "tool.ts"),
       OPENREACTOR_ISSUE_NUMBER: String(issue.number),
       OPENREACTOR_ISSUE_URL: issue.html_url,
       OPENREACTOR_RUN_DIR: paths.runDir,
@@ -747,7 +753,7 @@ export async function runIssueTriage(input: {
   comments?: GitHubIssueComment[];
 }): Promise<{ result: TriageResult | null; exitCode: number | null; execution: ExecutionMetadata }> {
   const { config, issue, paths, githubToken } = input;
-  const schemaPath = path.join(config.repoRoot, "reactor", "triage-result.schema.json");
+  const schemaPath = path.join(config.engineRoot, "reactor", "triage-result.schema.json");
   const prompt = await buildTriagePrompt(config, issue, paths, input.comments ?? []);
   const referenceImages = await prepareRunReferenceImages(issue, paths, input.comments ?? []);
 
@@ -774,6 +780,8 @@ export async function runIssueTriage(input: {
       GITHUB_TOKEN: githubToken,
       OPENREACTOR_REPO_OWNER: config.owner,
       OPENREACTOR_REPO_NAME: config.repo,
+      OPENREACTOR_ENGINE_ROOT: config.engineRoot,
+      OPENREACTOR_ENGINE_TOOL: path.join(config.engineRoot, "reactor", "tool.ts"),
       OPENREACTOR_ISSUE_NUMBER: String(issue.number),
       OPENREACTOR_ISSUE_URL: issue.html_url,
       OPENREACTOR_RUN_DIR: paths.runDir
@@ -856,21 +864,21 @@ async function buildAgentPrompt(
   const repoDocs = await resolveRepoDocumentationPaths(paths.worktreePath);
   const extraFiles =
     agentTool === "spawn_claude_ui_agent"
-      ? ["- prompts/ui-agent.md"]
+      ? [`- ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "ui-agent.md"))}`]
       : agentTool === "spawn_codex_planner_agent"
-        ? ["- prompts/planner-agent.md"]
+        ? [`- ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "planner-agent.md"))}`]
         : [];
   const toolRules =
     agentTool === "spawn_claude_ui_agent"
       ? [
           `- This issue was dispatched via ${tool.label}. Treat it as a UI-heavy task unless the code proves otherwise.`,
-          "- Use prompts/ui-agent.md as your frontend design skill equivalent while making design decisions.",
+          `- Use ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "ui-agent.md"))} as your frontend design skill equivalent while making design decisions.`,
           "- Prefer tight, polished UI work over broad refactors when solving the issue."
         ]
       : agentTool === "spawn_codex_planner_agent"
         ? [
             `- This issue was dispatched via ${tool.label}. Your primary job is to decide whether the request should be decomposed into multiple smaller issues instead of being implemented directly.`,
-            "- Use prompts/planner-agent.md as the planning-specific rule set for this run.",
+            `- Use ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "planner-agent.md"))} as the planning-specific rule set for this run.`,
             "- If the request is worth pursuing but too large, return `decomposed` with a structured decomposition plan instead of `rejected`.",
             "- When decomposing, use `dependsOn` only for true blocking relationships between child tasks. Leave it empty for tasks that can proceed in parallel.",
             "- Do not open a PR for the oversized parent issue itself."
@@ -884,15 +892,15 @@ async function buildAgentPrompt(
     "",
     "Read these files before doing anything else:",
     ...(repoDocs.uiSystem ? [`- ${relativeFromWorktree(paths, repoDocs.uiSystem)}`] : []),
-    "- prompts/product-context.md",
-    "- prompts/issue-agent.md",
-    "- prompts/quality-gates.md",
+    `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "product-context.md"))}`,
+    `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "issue-agent.md"))}`,
+    `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "quality-gates.md"))}`,
     `- ${relativeFromWorktree(paths, repoDocs.productSpec)}`,
     `- ${relativeFromWorktree(paths, repoDocs.productConstitution)}`,
     `- ${relativeFromWorktree(paths, repoDocs.roadmap)}`,
     `- ${relativeFromWorktree(paths, repoDocs.memory)}`,
     `- ${relativeFromWorktree(paths, repoDocs.readme)}`,
-    "- OPENREACTOR_WORKFLOW.md",
+    `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "OPENREACTOR_WORKFLOW.md"))}`,
     ...extraFiles,
     `- ${relativeFromWorktree(paths, paths.contextPath)}`,
     `- ${relativeFromWorktree(paths, paths.planPath)}`,
@@ -925,8 +933,8 @@ async function buildAgentPrompt(
     "- If you discover durable learnings, update the relevant shared docs in prompts/, MEMORY.md, CONSTITUTION.md, PRODUCT_CONSTITUTION.md, OPENREACTOR_WORKFLOW.md, or nearby docs.",
     "- Never commit secrets, API keys, private tokens, or credentials.",
     "- Use gh for GitHub issue and PR operations. GH_TOKEN is already available.",
-    "- Use `bun run reactor:tool ensure-plan ...` if the plan scaffold needs to be restored.",
-    "- Use `bun run reactor:tool ensure-pr ...` when finishing an accepted run so PR creation is idempotent.",
+    `- Use \`bun ${JSON.stringify(path.join(config.engineRoot, "reactor", "tool.ts"))} ensure-plan ...\` if the plan scaffold needs to be restored.`,
+    `- Use \`bun ${JSON.stringify(path.join(config.engineRoot, "reactor", "tool.ts"))} ensure-pr ...\` when finishing an accepted run so PR creation is idempotent.`,
     `- Keep the claim label ${config.runningLabel} in place if more iterations are needed.`,
     `- If you finish with accepted or rejected, remove ${config.runningLabel} yourself and apply the final label.`,
     "- If you return accepted, the reactor will verify that a remote branch exists, a PR exists for the branch, at least one reported check passed, and no reported checks failed.",
@@ -970,16 +978,16 @@ async function buildTriagePrompt(
     `You are OpenReactor's lightweight issue triage agent for GitHub issue #${issue.number}.`,
     "",
     "Read these files before deciding:",
-    "- prompts/triage-agent.md",
-    "- prompts/product-context.md",
-    "- prompts/issue-agent.md",
-    "- CONSTITUTION.md",
-    `- ${relativeFromWorktree(paths, repoDocs.productSpec)}`,
-    `- ${relativeFromWorktree(paths, repoDocs.productConstitution)}`,
-    "- OPENREACTOR_WORKFLOW.md",
-    `- ${relativeFromWorktree(paths, repoDocs.roadmap)}`,
-    `- ${relativeFromWorktree(paths, repoDocs.memory)}`,
-    `- ${relativeFromWorktree(paths, repoDocs.readme)}`,
+    `- ${relativeFromRepo(config, path.join(config.engineRoot, "prompts", "triage-agent.md"))}`,
+    `- ${relativeFromRepo(config, path.join(config.engineRoot, "prompts", "product-context.md"))}`,
+    `- ${relativeFromRepo(config, path.join(config.engineRoot, "prompts", "issue-agent.md"))}`,
+    `- ${relativeFromRepo(config, path.join(config.engineRoot, "CONSTITUTION.md"))}`,
+    `- ${relativeFromRepo(config, repoDocs.productSpec)}`,
+    `- ${relativeFromRepo(config, repoDocs.productConstitution)}`,
+    `- ${relativeFromRepo(config, path.join(config.engineRoot, "OPENREACTOR_WORKFLOW.md"))}`,
+    `- ${relativeFromRepo(config, repoDocs.roadmap)}`,
+    `- ${relativeFromRepo(config, repoDocs.memory)}`,
+    `- ${relativeFromRepo(config, repoDocs.readme)}`,
     "",
     "Issue context:",
     `- Issue: #${issue.number}`,

--- a/scripts/reactor-service.sh
+++ b/scripts/reactor-service.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_ROOT="/home/ray/projects/openreactor"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="${OPENREACTOR_MANAGED_REPO_ROOT:-$ENGINE_ROOT}"
 ENV_FILE="${OPENREACTOR_ENV_FILE:-/home/ray/.config/openreactor/reactor.env}"
 
 cd "$REPO_ROOT"
@@ -54,4 +56,5 @@ if [[ -z "${GITHUB_APP_ID:-}" || -z "${GITHUB_APP_PRIVATE_KEY:-}" ]]; then
   fi
 fi
 
-exec /home/ray/.bun/bin/bun /home/ray/projects/openreactor/reactor/index.ts "$@"
+export OPENREACTOR_ENGINE_ROOT="${OPENREACTOR_ENGINE_ROOT:-$ENGINE_ROOT}"
+exec /home/ray/.bun/bin/bun "$ENGINE_ROOT/reactor/index.ts" "$@"

--- a/scripts/watchdog-service.sh
+++ b/scripts/watchdog-service.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_ROOT="/home/ray/projects/openreactor"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="${OPENREACTOR_MANAGED_REPO_ROOT:-$ENGINE_ROOT}"
 ENV_FILE="${OPENREACTOR_ENV_FILE:-/home/ray/.config/openreactor/reactor.env}"
 
 cd "$REPO_ROOT"
@@ -25,4 +27,5 @@ if [[ -f "$ENV_FILE" ]]; then
   set +a
 fi
 
-exec /home/ray/.bun/bin/bun /home/ray/projects/openreactor/watchdog/index.ts "$@"
+export OPENREACTOR_ENGINE_ROOT="${OPENREACTOR_ENGINE_ROOT:-$ENGINE_ROOT}"
+exec /home/ray/.bun/bin/bun "$ENGINE_ROOT/watchdog/index.ts" "$@"


### PR DESCRIPTION
## Summary
- split OpenReactor engine root from managed repo root so the same local engine can run against another cloned repo
- automatically open a bootstrap PR when a managed repo is missing committed `.openreactor/repo/` state
- document the manual multi-repo local runtime flow and the bootstrap gating rules

## Verification
- `bun run check`
- `bun run reactor:dry-run`
- temp managed-repo dry run with `OPENREACTOR_MANAGED_REPO_ROOT` set to a fresh repo clone
