### PR TITLE
Tag repo owner for maintainer handoffs

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -105,6 +105,11 @@
   maintainer action instead of merging a documented partial.
   Reason: maintainer-blocked features need a real waiting state in the workflow,
   not just handoff text inside an otherwise accepted PR.
+- Decision: when a run enters the maintainer-handoff state, OpenReactor should
+  tag the repo owner on both the issue and the PR.
+  Reason: maintainer-only steps need a deterministic GitHub notification path,
+  and that notification should go to the single highest-authority maintainer
+  instead of all contributors.
 
 - Decision: expose local OpenReactor runtime state through a machine-local
   read-only metadata service and let the website handle visualization.

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -78,6 +78,9 @@ maintainer consideration.
 - When a product issue is blocked on a maintainer-only prerequisite, OpenReactor
   should leave a reviewable PR open, disable auto-merge, and mark the issue as
   waiting for maintainer action instead of merging a documented partial.
+- In that maintainer-handoff path, OpenReactor should tag the repo owner on the
+  issue and the PR so the notification goes to the single highest-authority
+  maintainer rather than broadcasting to all contributors.
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,9 @@ default; agents should pass `--no-auto-merge` when a PR must wait for manual
 review or human intervention. If a feature is blocked on a maintainer-only step
 such as OAuth setup or secret provisioning, the reactor now leaves the PR open,
 disables auto-merge, and applies `maintainer-action-required` instead of
-merging a documented partial. Accepted issues are also re-queued automatically
+merging a documented partial. In that maintainer-handoff path, OpenReactor tags
+the repo owner on both the issue and the PR so the single highest-authority
+maintainer gets a direct GitHub notification. Accepted issues are also re-queued automatically
 if their open PR becomes unmergeable due to merge conflicts, and the reactor
 also sweeps all open `openreactor/issue-*` PRs each tick so conflicted follow-up
 branches get re-claimed even when the issue itself is already closed.

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -1084,21 +1084,33 @@ class Reactor {
             detail: `Waiting on maintainer action before PR ${handoffValidation.pullRequest.html_url} can continue.`,
             execution: activeRun.record.lastAgentExecution ?? undefined
           });
+          const maintainerMention = formatMaintainerOwnerMention(this.config.owner);
+          const handoffBody = formatPublicDecisionComment(
+            [
+              `${maintainerMention} maintainer action required.`,
+              "",
+              result.issueComment || result.summary,
+              "",
+              `OpenReactor left PR ${handoffValidation.pullRequest.html_url} open and disabled auto-merge because a maintainer-only action is still required.`,
+              "",
+              "Maintainer action required:",
+              result.humanHandoff.instructions
+            ].join("\n"),
+            result.considerations,
+            activeRun.record.lastAgentExecution,
+            "Implementation"
+          );
+          await this.github.createComment(issueNumber, handoffBody);
           await this.github.createComment(
-            issueNumber,
-            formatPublicDecisionComment(
-              [
-                result.issueComment || result.summary,
-                "",
-                `OpenReactor left PR ${handoffValidation.pullRequest.html_url} open and disabled auto-merge because a maintainer-only action is still required.`,
-                "",
-                "Maintainer action required:",
-                result.humanHandoff.instructions
-              ].join("\n"),
-              result.considerations,
-              activeRun.record.lastAgentExecution,
-              "Implementation"
-            )
+            handoffValidation.pullRequest.number,
+            [
+              `${maintainerMention} maintainer action required before this PR can merge.`,
+              "",
+              "OpenReactor disabled auto-merge for this PR because the remaining step requires the repo owner.",
+              "",
+              "Maintainer action required:",
+              result.humanHandoff.instructions
+            ].join("\n")
           );
           return;
         }
@@ -1573,6 +1585,11 @@ function formatExecutionLine(execution: ExecutionMetadata): string {
   ].filter(Boolean);
 
   return parts.join(" • ");
+}
+
+function formatMaintainerOwnerMention(owner: string): string {
+  const login = owner.trim().replace(/^@+/, "");
+  return login ? `@${login}` : "Maintainer";
 }
 
 function formatDurationMs(durationMs: number): string {


### PR DESCRIPTION
## Summary
- tag the repo owner when OpenReactor leaves an issue waiting on maintainer action
- add the same owner mention to the corresponding PR so the right person gets notified there too
- document owner-only maintainer-handoff notifications in the OpenReactor docs

## Testing
- bun run check
