### PR TITLE
Add provider fallback for issue agents

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -215,6 +215,11 @@
   Reason: maintainers need per-instance visibility for debugging and oversight,
   but those extra endpoints should stay laptop/local-facing by default instead
   of being automatically wired into the public OpenReactor website.
+- Decision: if the selected implementation provider is unavailable, OpenReactor
+  should retry the issue through the other provider before pausing it.
+  Reason: transient Claude/OpenAI outages are common enough that automatic
+  cross-provider failover is a cheaper recovery path than immediately burning
+  retries or waiting for manual intervention.
 - Decision: the intended onboarding flow for managed repos should infer a
   first-pass product description from the repo README and existing GitHub
   issues, then open a bootstrap PR creating `.openreactor/repo/`.

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -60,6 +60,10 @@ maintainer consideration.
 - OpenReactor should surface hard execution facts in public workflow artifacts
   where possible, such as provider, model, reasoning effort, and runtime
   duration, instead of relying only on narrative summaries.
+- If the selected implementation provider is unavailable, OpenReactor should
+  retry the run through the other provider before giving up on the issue. Only
+  when both providers appear unavailable should it pause the issue and wait for
+  provider recovery.
 - If an issue includes reference images, OpenReactor should treat them as
   first-class input. Codex-capable runs should receive the actual image files,
   not only markdown links to them. If another implementation path cannot

--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ The reactor currently:
 - creates a dedicated git worktree per issue from the latest `origin/main`
 - persists per-issue run files under `.openreactor/`
 - retries the same issue until it reaches a real terminal state
+- falls back to the other AI provider when the selected implementation provider
+  appears unavailable, and pauses cleanly only if both providers are down
 - reconsiders banked, paused, or previously rejected issues when later
   discussion materially refines the task or explicitly calls the bot back in,
   even if the issue had only been parked in GitHub state and never reached a

--- a/reactor/agent-tools.ts
+++ b/reactor/agent-tools.ts
@@ -1,6 +1,8 @@
 export type AgentToolName =
   | "spawn_codex_issue_agent"
   | "spawn_codex_planner_agent"
+  | "spawn_claude_issue_agent"
+  | "spawn_claude_planner_agent"
   | "spawn_claude_ui_agent";
 
 export interface AgentToolDefinition {
@@ -9,6 +11,7 @@ export interface AgentToolDefinition {
   description: string;
   provider: "codex" | "claude";
   primaryUse: "general" | "planning" | "ui";
+  triageSelectable: boolean;
 }
 
 export const DEFAULT_AGENT_TOOL: AgentToolName = "spawn_codex_issue_agent";
@@ -20,7 +23,8 @@ export const AGENT_TOOLS: Record<AgentToolName, AgentToolDefinition> = {
     description:
       "General-purpose implementation agent for product, backend, orchestration, API, and non-UI tasks.",
     provider: "codex",
-    primaryUse: "general"
+    primaryUse: "general",
+    triageSelectable: true
   },
   spawn_codex_planner_agent: {
     name: "spawn_codex_planner_agent",
@@ -28,7 +32,26 @@ export const AGENT_TOOLS: Record<AgentToolName, AgentToolDefinition> = {
     description:
       "Planning-focused Codex agent for oversized but worthwhile requests that should be decomposed into smaller executable issues.",
     provider: "codex",
-    primaryUse: "planning"
+    primaryUse: "planning",
+    triageSelectable: true
+  },
+  spawn_claude_issue_agent: {
+    name: "spawn_claude_issue_agent",
+    label: "Claude Issue Agent",
+    description:
+      "General-purpose Claude fallback agent for product, backend, orchestration, API, and non-UI tasks when the preferred provider is unavailable.",
+    provider: "claude",
+    primaryUse: "general",
+    triageSelectable: false
+  },
+  spawn_claude_planner_agent: {
+    name: "spawn_claude_planner_agent",
+    label: "Claude Planner Agent",
+    description:
+      "Planning-focused Claude fallback agent for oversized requests when the preferred provider is unavailable.",
+    provider: "claude",
+    primaryUse: "planning",
+    triageSelectable: false
   },
   spawn_claude_ui_agent: {
     name: "spawn_claude_ui_agent",
@@ -36,7 +59,8 @@ export const AGENT_TOOLS: Record<AgentToolName, AgentToolDefinition> = {
     description:
       "Frontend-focused implementation agent for visual design, layout, styling, interaction polish, and other UI-heavy work.",
     provider: "claude",
-    primaryUse: "ui"
+    primaryUse: "ui",
+    triageSelectable: true
   }
 };
 
@@ -44,6 +68,8 @@ export function isAgentToolName(value: string | null | undefined): value is Agen
   return (
     value === "spawn_codex_issue_agent" ||
     value === "spawn_codex_planner_agent" ||
+    value === "spawn_claude_issue_agent" ||
+    value === "spawn_claude_planner_agent" ||
     value === "spawn_claude_ui_agent"
   );
 }
@@ -58,6 +84,26 @@ export function getAgentTool(value: string | null | undefined): AgentToolDefinit
 
 export function describeAgentToolsForPrompt(): string {
   return Object.values(AGENT_TOOLS)
+    .filter((tool) => tool.triageSelectable)
     .map((tool) => `- \`${tool.name}\`: ${tool.description}`)
     .join("\n");
+}
+
+export function getFallbackToolForProviderOutage(
+  value: AgentToolName | null | undefined
+): AgentToolName | null {
+  switch (value) {
+    case "spawn_codex_issue_agent":
+      return "spawn_claude_issue_agent";
+    case "spawn_codex_planner_agent":
+      return "spawn_claude_planner_agent";
+    case "spawn_claude_issue_agent":
+      return "spawn_codex_issue_agent";
+    case "spawn_claude_planner_agent":
+      return "spawn_codex_planner_agent";
+    case "spawn_claude_ui_agent":
+      return "spawn_codex_issue_agent";
+    default:
+      return null;
+  }
 }

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import { loadConfig, type OrchestratorConfig } from "./config";
 import {
   DEFAULT_AGENT_TOOL,
+  getFallbackToolForProviderOutage,
   getAgentTool,
   isAgentToolName,
   type AgentToolName
@@ -39,6 +40,7 @@ import {
   type RunRecord,
   type TriageResult
 } from "./runner";
+import { detectProviderOutage } from "./provider-outage";
 import {
   ensureRepoRuntimeGitignore,
   hasRepoStateFiles,
@@ -906,6 +908,8 @@ class Reactor {
       existingRecord ??
       (await readRunRecord(paths)) ??
       (await createInitialRunRecord(issue, paths));
+    record.preferredAgentTool =
+      selectedTriage?.toolName ?? record.preferredAgentTool ?? requestedAgentTool;
     record.targetSurface = selectedTriage?.targetSurface ?? record.targetSurface;
     record.sensitivity = selectedTriage?.sensitivity ?? record.sensitivity;
     record.evidenceStrength = selectedTriage?.evidenceStrength ?? record.evidenceStrength;
@@ -1004,6 +1008,13 @@ class Reactor {
     const failureMessage = `${input.phase}: ${formatError(input.error)}`;
 
     record.agentTool = input.selectedTool ?? record.agentTool;
+    if (
+      record.agentTool &&
+      (await this.handleProviderOutageFallback(issue, record, record.agentTool, failureMessage, input.phase))
+    ) {
+      return;
+    }
+
     record.startFailureCount = nextStartFailureCount;
     record.status =
       nextStartFailureCount >= this.config.maxStartFailuresPerIssue ? "failed" : "retry";
@@ -1055,6 +1066,20 @@ class Reactor {
         activeRun,
         paths
       });
+
+      if (
+        !result &&
+        activeRun.record.agentTool &&
+        (await this.handleProviderOutageFallback(
+          activeRun.issue,
+          activeRun.record,
+          activeRun.record.agentTool,
+          await readProviderFailureContext(activeRun.logPath, exitCode),
+          "runtime"
+        ))
+      ) {
+        return;
+      }
 
       if (result?.humanHandoff?.required) {
         const handoffValidation = await this.validateMaintainerHandoff(paths.branchName, result);
@@ -1288,6 +1313,104 @@ class Reactor {
       }
       await this.updateLiveStatus();
     }
+  }
+
+  private async handleProviderOutageFallback(
+    issue: GitHubIssue,
+    record: RunRecord,
+    currentToolName: AgentToolName,
+    failureMessage: string,
+    phase: "triage" | "startup" | "retry-startup" | "runtime"
+  ): Promise<boolean> {
+    const provider = getAgentTool(currentToolName).provider;
+    const outageReason = detectProviderOutage(provider, failureMessage);
+    if (!outageReason) {
+      return false;
+    }
+
+    const preferredToolName = record.preferredAgentTool ?? currentToolName;
+    const preferredFallbackToolName =
+      preferredToolName !== currentToolName &&
+      getAgentTool(preferredToolName).provider !== provider
+        ? preferredToolName
+        : null;
+    const fallbackToolName =
+      preferredFallbackToolName ?? getFallbackToolForProviderOutage(currentToolName);
+    const triedTools = uniqueAgentTools([...(record.providerFallbackToolsTried ?? []), currentToolName]);
+    const fallbackAvailable = fallbackToolName && !triedTools.includes(fallbackToolName);
+
+    if (fallbackAvailable && fallbackToolName) {
+      const currentTool = getAgentTool(currentToolName);
+      const fallbackTool = getAgentTool(fallbackToolName);
+
+      record.providerFallbackToolsTried = triedTools;
+      record.agentTool = fallbackToolName;
+      record.status = "retry";
+      record.lastError =
+        `${phase}: ${currentTool.label} hit a provider outage (${outageReason}). ` +
+        `Falling back to ${fallbackTool.label}.`;
+      record.updatedAt = new Date().toISOString();
+      record.lastHeartbeatAt = record.updatedAt;
+      await writeRunRecord(issueRuntimePaths(this.config, issue.number), record);
+      await this.syncIssueStatusComment(issue.number, {
+        status: "queued",
+        phase: "retrying",
+        iteration: record.iteration,
+        detail:
+          `${currentTool.label} appears unavailable (${outageReason}), so OpenReactor is ` +
+          `falling back to ${fallbackTool.label}.`
+      });
+
+      await sleep(2_000);
+      if (this.stopped) {
+        return true;
+      }
+
+      const refreshedIssue = await this.github.getIssue(issue.number);
+      await this.startIssue(refreshedIssue, record);
+      return true;
+    }
+
+    const providerLabels = uniqueProviderLabels(triedTools);
+    if (!providerLabels.includes("Codex")) {
+      providerLabels.push("Codex");
+    }
+    if (!providerLabels.includes("Claude")) {
+      providerLabels.push("Claude");
+    }
+
+    record.agentTool = preferredToolName;
+    record.providerFallbackToolsTried = [];
+    record.status = "failed";
+    record.lastError =
+      `${phase}: both AI providers appear unavailable. Last provider outage: ${outageReason}.`;
+    record.updatedAt = new Date().toISOString();
+    record.lastHeartbeatAt = record.updatedAt;
+    await writeRunRecord(issueRuntimePaths(this.config, issue.number), record);
+
+    await this.github.removeLabel(issue.number, this.config.runningLabel);
+    await this.github.addLabels(issue.number, [this.config.pausedLabel]);
+    await this.syncIssueStatusComment(issue.number, {
+      status: "queued",
+      phase: "paused",
+      iteration: record.iteration,
+      detail:
+        `${providerLabels.join(" and ")} both appear unavailable, so OpenReactor paused this ` +
+        `issue until a provider recovers.`
+    });
+    await this.github.createComment(
+      issue.number,
+      [
+        "OpenReactor paused this issue because both AI providers appear unavailable.",
+        "",
+        `Phase: ${phase}`,
+        `Last provider outage signal: ${outageReason}`,
+        `Preferred tool: ${getAgentTool(preferredToolName).label}`,
+        "",
+        `The watchdog can retry this issue automatically once provider availability recovers, or you can remove \`${this.config.pausedLabel}\` to let the reactor reclaim it later.`
+      ].join("\n")
+    );
+    return true;
   }
 
   private async refreshPullRequestExecutionFooter(
@@ -1585,6 +1708,31 @@ function formatExecutionLine(execution: ExecutionMetadata): string {
   ].filter(Boolean);
 
   return parts.join(" • ");
+}
+
+async function readProviderFailureContext(logPath: string, exitCode: number | null): Promise<string> {
+  const logTail = await readLogTail(logPath, 8000);
+  return [logTail, `exit code: ${exitCode ?? "unknown"}`].filter(Boolean).join("\n");
+}
+
+async function readLogTail(logPath: string, maxChars: number): Promise<string> {
+  try {
+    const contents = await fs.readFile(logPath, "utf8");
+    return contents.slice(Math.max(0, contents.length - maxChars));
+  } catch {
+    return "";
+  }
+}
+
+function uniqueAgentTools(values: AgentToolName[]): AgentToolName[] {
+  return Array.from(new Set(values));
+}
+
+function uniqueProviderLabels(values: AgentToolName[]): string[] {
+  const labels = values.map((toolName) =>
+    getAgentTool(toolName).provider === "claude" ? "Claude" : "Codex"
+  );
+  return Array.from(new Set(labels));
 }
 
 function formatMaintainerOwnerMention(owner: string): string {

--- a/reactor/provider-outage.ts
+++ b/reactor/provider-outage.ts
@@ -1,0 +1,75 @@
+export type ProviderKey = "codex" | "claude";
+
+const GENERIC_OUTAGE_PATTERNS = [
+  "rate limit",
+  "too many requests",
+  "overloaded",
+  "temporarily unavailable",
+  "service unavailable",
+  "server had an error while processing your request",
+  "internal server error",
+  "api connection error",
+  "connection error",
+  "connection reset",
+  "econnreset",
+  "timed out",
+  "timeout",
+  "bad gateway",
+  "upstream connect error",
+  "error 502",
+  "error 503",
+  "error 529"
+] as const;
+
+const PROVIDER_SPECIFIC_PATTERNS: Record<ProviderKey, readonly string[]> = {
+  codex: ["openai", "codex"],
+  claude: ["anthropic", "claude"]
+};
+
+export function detectProviderOutage(
+  provider: ProviderKey,
+  message: string | null | undefined
+): string | null {
+  const normalized = normalizeMessage(message);
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized.includes("both ai providers appear unavailable")) {
+    return "both AI providers appear unavailable";
+  }
+
+  const matchedPattern = GENERIC_OUTAGE_PATTERNS.find((pattern) => normalized.includes(pattern));
+  if (!matchedPattern) {
+    return null;
+  }
+
+  const mentionsProvider = PROVIDER_SPECIFIC_PATTERNS[provider].some((pattern) =>
+    normalized.includes(pattern)
+  );
+
+  if (!mentionsProvider && !looksProviderGeneratedFailure(normalized)) {
+    return null;
+  }
+
+  return matchedPattern;
+}
+
+export function looksProviderGeneratedFailure(message: string | null | undefined): boolean {
+  const normalized = normalizeMessage(message);
+  if (!normalized) {
+    return false;
+  }
+
+  return (
+    normalized.includes("api error") ||
+    normalized.includes("provider") ||
+    normalized.includes("model") ||
+    normalized.includes("request id") ||
+    normalized.includes("x-request-id")
+  );
+}
+
+function normalizeMessage(message: string | null | undefined): string {
+  return (message ?? "").trim().toLowerCase();
+}

--- a/reactor/runner.ts
+++ b/reactor/runner.ts
@@ -86,6 +86,8 @@ export interface RunRecord {
   issueTitle: string;
   branchName: string;
   agentTool?: AgentToolName;
+  preferredAgentTool?: AgentToolName;
+  providerFallbackToolsTried?: AgentToolName[];
   targetSurface?: ProductSurfaceTarget;
   sensitivity?: SurfaceSensitivity;
   evidenceStrength?: EvidenceStrength;
@@ -454,6 +456,12 @@ export async function spawnIssueAgent(input: {
   if (tool.name === "spawn_codex_planner_agent") {
     return spawnCodexPlannerAgent(input);
   }
+  if (tool.name === "spawn_claude_planner_agent") {
+    return spawnClaudePlannerAgent(input);
+  }
+  if (tool.name === "spawn_claude_issue_agent") {
+    return spawnClaudeIssueAgent(input);
+  }
   if (tool.provider === "claude") {
     return spawnClaudeUiIssueAgent(input);
   }
@@ -661,13 +669,46 @@ async function spawnClaudeUiIssueAgent(input: {
   record: RunRecord;
   githubToken: string;
 }): Promise<ActiveRun> {
+  return spawnClaudeAgent(input, "spawn_claude_ui_agent");
+}
+
+async function spawnClaudeIssueAgent(input: {
+  config: OrchestratorConfig;
+  issue: GitHubIssue;
+  paths: IssueRuntimePaths;
+  record: RunRecord;
+  githubToken: string;
+}): Promise<ActiveRun> {
+  return spawnClaudeAgent(input, "spawn_claude_issue_agent");
+}
+
+async function spawnClaudePlannerAgent(input: {
+  config: OrchestratorConfig;
+  issue: GitHubIssue;
+  paths: IssueRuntimePaths;
+  record: RunRecord;
+  githubToken: string;
+}): Promise<ActiveRun> {
+  return spawnClaudeAgent(input, "spawn_claude_planner_agent");
+}
+
+async function spawnClaudeAgent(
+  input: {
+    config: OrchestratorConfig;
+    issue: GitHubIssue;
+    paths: IssueRuntimePaths;
+    record: RunRecord;
+    githubToken: string;
+  },
+  toolName: AgentToolName
+): Promise<ActiveRun> {
   const { config, issue, paths, githubToken } = input;
   const iteration = input.record.iteration + 1;
   const schemaPath = path.join(config.engineRoot, "reactor", "agent-result.schema.json");
   const resultPath = path.join(paths.runDir, `iteration-${iteration}.result.json`);
   const logPath = path.join(paths.runDir, `iteration-${iteration}.log`);
   const promptPath = path.join(paths.runDir, `iteration-${iteration}.prompt.md`);
-  const prompt = await buildAgentPrompt(config, issue, paths, iteration, "spawn_claude_ui_agent");
+  const prompt = await buildAgentPrompt(config, issue, paths, iteration, toolName);
   const schema = await fs.readFile(schemaPath, "utf8");
 
   await fs.writeFile(promptPath, prompt, "utf8");
@@ -707,7 +748,7 @@ async function spawnClaudeUiIssueAgent(input: {
 
   const record: RunRecord = {
     ...input.record,
-    agentTool: "spawn_claude_ui_agent",
+    agentTool: toolName,
     status: "running",
     iteration,
     startFailureCount: 0,
@@ -737,9 +778,9 @@ async function spawnClaudeUiIssueAgent(input: {
       model: config.claudeUiModel,
       reasoningEffort: config.claudeUiEffort,
       serviceTier: null,
-      toolName: "spawn_claude_ui_agent",
-      toolLabel: getAgentTool("spawn_claude_ui_agent").label,
-      primaryUse: getAgentTool("spawn_claude_ui_agent").primaryUse
+      toolName,
+      toolLabel: getAgentTool(toolName).label,
+      primaryUse: getAgentTool(toolName).primaryUse
     },
     parseResult: () => parseClaudeAgentResult(stdoutChunks, resultPath)
   };
@@ -865,7 +906,7 @@ async function buildAgentPrompt(
   const extraFiles =
     agentTool === "spawn_claude_ui_agent"
       ? [`- ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "ui-agent.md"))}`]
-      : agentTool === "spawn_codex_planner_agent"
+      : agentTool === "spawn_codex_planner_agent" || agentTool === "spawn_claude_planner_agent"
         ? [`- ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "planner-agent.md"))}`]
         : [];
   const toolRules =
@@ -875,6 +916,20 @@ async function buildAgentPrompt(
           `- Use ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "ui-agent.md"))} as your frontend design skill equivalent while making design decisions.`,
           "- Prefer tight, polished UI work over broad refactors when solving the issue."
         ]
+      : agentTool === "spawn_claude_planner_agent"
+        ? [
+            `- This issue is running via ${tool.label} because the preferred provider was unavailable.`,
+            `- Use ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "planner-agent.md"))} as the planning-specific rule set for this run.`,
+            "- Your primary job is still to decide whether the request should be decomposed into multiple smaller issues instead of being implemented directly.",
+            "- If the request is worth pursuing but too large, return `decomposed` with a structured decomposition plan instead of `rejected`.",
+            "- Use `dependsOn` only for true blocking relationships between child tasks. Leave it empty for tasks that can proceed in parallel.",
+            "- Do not open a PR for the oversized parent issue itself."
+          ]
+        : agentTool === "spawn_claude_issue_agent"
+          ? [
+              `- This issue is running via ${tool.label} because the preferred provider was unavailable.`,
+              "- Handle it as the general-purpose implementation path, not as a UI-specialized run."
+            ]
       : agentTool === "spawn_codex_planner_agent"
         ? [
             `- This issue was dispatched via ${tool.label}. Your primary job is to decide whether the request should be decomposed into multiple smaller issues instead of being implemented directly.`,

--- a/watchdog/index.ts
+++ b/watchdog/index.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import process from "node:process";
 import { loadConfig as loadReactorConfig } from "../reactor/config";
 import { GitHubClient, type GitHubIssue } from "../reactor/github";
+import { detectProviderOutage } from "../reactor/provider-outage";
 import { issueRuntimePaths, readRunRecord, type RunRecord } from "../reactor/runner";
 import { loadWatchdogConfig, type WatchdogConfig } from "./config";
 
@@ -15,6 +16,7 @@ type FailureClass =
   | "none"
   | "rate_limit"
   | "auth"
+  | "provider_unavailable"
   | "schema_mismatch"
   | "missing_binary"
   | "runaway_iterations"
@@ -773,6 +775,19 @@ function classifyFailure(message: string): FailureInfo {
       className: "auth",
       retryable: false,
       global: true,
+      requiresCodeChange: false
+    };
+  }
+
+  if (
+    normalized.includes("both ai providers appear unavailable") ||
+    Boolean(detectProviderOutage("codex", normalized)) ||
+    Boolean(detectProviderOutage("claude", normalized))
+  ) {
+    return {
+      className: "provider_unavailable",
+      retryable: true,
+      global: false,
       requiresCodeChange: false
     };
   }


### PR DESCRIPTION
## Summary
- add cross-provider fallback for issue and planner runs when the selected AI provider is unavailable
- pause issues cleanly only after both providers appear unavailable, so the watchdog can retry later
- document provider failover as a first-class OpenReactor workflow behavior

## Testing
- bun run check
