### PR TITLE
Fallback to direct merge when native auto-merge is unsupported

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -195,6 +195,13 @@
   see the label before the run record exists and incorrectly strip the claim
   from live work.
 
+- Decision: if GitHub's native auto-merge is unsupported for a repo, the PR
+  helper should fall back to a direct merge for clean accepted PRs instead of
+  leaving them open forever.
+  Reason: some managed repos do not use protected-branch auto-merge, and
+  stalled accepted PRs can deadlock downstream issue dependencies even though
+  the work is already mergeable.
+
 - Decision: persist intake-form reference image uploads in a dedicated
   GitHub-backed assets branch and embed those hosted URLs into the created
   issue body.

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -64,6 +64,10 @@ maintainer consideration.
   retry the run through the other provider before giving up on the issue. Only
   when both providers appear unavailable should it pause the issue and wait for
   provider recovery.
+- When OpenReactor asks GitHub for auto-merge on an accepted PR, it should
+  fall back to a direct merge only when the target repo does not support
+  native GitHub auto-merge at all. Clean accepted PRs should not be left open
+  forever just because the repo has no protected-branch auto-merge support.
 - If an issue includes reference images, OpenReactor should treat them as
   first-class input. Codex-capable runs should receive the actual image files,
   not only markdown links to them. If another implementation path cannot

--- a/README.md
+++ b/README.md
@@ -399,7 +399,10 @@ bun run smoke:pages -- --base-url https://openreactor.net --cleanup
 App installation token already injected into the run. That avoids using the
 server's SSH identity for remote publication. It also enables PR auto-merge by
 default; agents should pass `--no-auto-merge` when a PR must wait for manual
-review or human intervention. If a feature is blocked on a maintainer-only step
+review or human intervention. On repos where GitHub's native auto-merge is not
+available, the helper now falls back to a direct merge only for that specific
+unsupported-native-auto-merge case, so clean accepted PRs do not stall
+dependency chains forever. If a feature is blocked on a maintainer-only step
 such as OAuth setup or secret provisioning, the reactor now leaves the PR open,
 disables auto-merge, and applies `maintainer-action-required` instead of
 merging a documented partial. In that maintainer-handoff path, OpenReactor tags

--- a/reactor/tool.ts
+++ b/reactor/tool.ts
@@ -380,6 +380,29 @@ async function enableAutoMerge(input: {
   mergeMethod: string;
 }): Promise<void> {
   const mergeMethodFlag = toMergeMethodFlag(input.mergeMethod);
+  try {
+    await execFileAsync(
+      "gh",
+      [
+        "pr",
+        "merge",
+        "--repo",
+        `${input.owner}/${input.repo}`,
+        "--auto",
+        mergeMethodFlag,
+        String(input.prNumber)
+      ],
+      {
+        env: process.env
+      }
+    );
+    return;
+  } catch (error) {
+    if (!isUnsupportedNativeAutoMergeError(error)) {
+      throw error;
+    }
+  }
+
   await execFileAsync(
     "gh",
     [
@@ -387,13 +410,27 @@ async function enableAutoMerge(input: {
       "merge",
       "--repo",
       `${input.owner}/${input.repo}`,
-      "--auto",
       mergeMethodFlag,
       String(input.prNumber)
     ],
     {
       env: process.env
     }
+  );
+}
+
+function isUnsupportedNativeAutoMergeError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const stderr = typeof (error as { stderr?: unknown }).stderr === "string"
+    ? (error as { stderr: string }).stderr
+    : "";
+  const combined = stderr.toLowerCase();
+  return (
+    combined.includes("protected branch rules not configured for this branch") ||
+    combined.includes("auto merge must be enabled for this repository")
   );
 }
 


### PR DESCRIPTION
## Summary
- fall back to a direct PR merge only when GitHub native auto-merge is unsupported for the target repo
- document the helper behavior in the engine docs and memory
- prevent clean accepted PRs from stalling dependency chains on repos without protected-branch auto-merge

## Verification
- bun run check
