### PR TITLE
Document self-healing-first incident response

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -223,11 +223,12 @@
   improve the shared engine. The repair should land in one place, then the
   watchdog should redeploy that updated engine to the affected local instances.
 
-- Decision: when a maintainer raises an OpenReactor-core problem, fix the
-  immediate incident and also add the durable engine/workflow fix for that
-  failure class.
+- Decision: when a maintainer raises an OpenReactor-core problem, land the
+  durable engine/workflow fix first and, whenever feasible, let that fix heal
+  the already-stuck work instead of doing a separate one-off manual recovery.
   Reason: OpenReactor should not keep relearning the same operational lessons
-  one incident at a time.
+  one incident at a time, and it should converge back to forward progress from
+  partially broken states through its own repaired workflow.
 
 - Decision: conflicted maintainer-authored core PRs outside the normal
   `openreactor/issue-*` branch pattern should still be surfaced as explicit

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -197,9 +197,15 @@ machine identity so commit authorship is visibly automated.
 When a maintainer surfaces an OpenReactor-core failure, the expected response
 should include both:
 
-- an immediate operational fix that gets blocked work moving again
 - a durable engine or workflow fix that prevents the same class of failure from
   recurring silently
+- and, whenever feasible, let that new fix heal the already-stuck work instead
+  of relying on a separate one-off manual recovery step
+
+Manual intervention is still allowed when the system cannot recover the stuck
+state without it, but the preferred pattern is self-healing through the engine
+fix itself. OpenReactor should be able to enter a partially broken state, land
+the repair, and then converge back to progress on its own.
 
 ## OpenReactor proposals
 


### PR DESCRIPTION
## Summary
- document that OpenReactor-core incidents should prefer the durable engine fix first
- clarify that the repaired engine should heal the already-stuck work whenever feasible

## Verification
- docs only
