### PR TITLE
Close merged maintainer handoff issues automatically

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -110,6 +110,11 @@
   Reason: maintainer-only steps need a deterministic GitHub notification path,
   and that notification should go to the single highest-authority maintainer
   instead of all contributors.
+- Decision: when a maintainer-hand-off PR is merged manually, OpenReactor
+  should close the source issue automatically on the next reconciliation tick.
+  Reason: a maintainer-merged PR is the terminal success condition for that
+  workflow, so leaving the issue open would strand completed work in a stale
+  `waiting-maintainer` state.
 
 - Decision: expose local OpenReactor runtime state through a machine-local
   read-only metadata service and let the website handle visualization.
@@ -229,6 +234,12 @@
   Reason: OpenReactor should not keep relearning the same operational lessons
   one incident at a time, and it should converge back to forward progress from
   partially broken states through its own repaired workflow.
+
+- Decision: treat idempotency and resumability as core OpenReactor properties,
+  not narrow recovery details.
+  Reason: the whole system should be safe to replay after partial failure, so
+  retries, reconciliations, and resumed runs converge on the same intended
+  state instead of depending on bespoke cleanup.
 
 - Decision: conflicted maintainer-authored core PRs outside the normal
   `openreactor/issue-*` branch pattern should still be surfaced as explicit

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -29,6 +29,9 @@ maintainer consideration.
 
 - Preserve OpenReactor's ability to safely supervise autonomous work.
 - Favor clear governance over convenience when the two conflict.
+- OpenReactor should be idempotent and resumable end to end. Replaying the
+  same workflow step after a partial failure should converge toward the same
+  intended result instead of corrupting state or requiring bespoke cleanup.
 - Protect secret handling, auth boundaries, deployment policy, and privileged
   internal controls.
 - Do not let random public feedback directly rewrite OpenReactor-governing
@@ -106,6 +109,9 @@ maintainer consideration.
 - In that maintainer-handoff path, OpenReactor should tag the repo owner on the
   issue and the PR so the notification goes to the single highest-authority
   maintainer rather than broadcasting to all contributors.
+- Once the maintainer merges that handoff PR, OpenReactor should automatically
+  reconcile the source issue to `completed` instead of leaving it open in a
+  stale `waiting-maintainer` state.
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ If that loop becomes reliable, software development changes shape. The
 bottleneck is no longer "can the model write code?" but "can the product
 govern itself well enough to evolve safely and coherently over time?"
 
+A core OpenReactor tenet is idempotency. The system should be safe to replay,
+resume, and reconcile after partial failure, so interrupted work converges back
+to the intended result instead of depending on one-off manual cleanup.
+
 ## Governance
 
 The system is intentionally not a literal ticket fulfiller.
@@ -407,7 +411,10 @@ such as OAuth setup or secret provisioning, the reactor now leaves the PR open,
 disables auto-merge, and applies `maintainer-action-required` instead of
 merging a documented partial. In that maintainer-handoff path, OpenReactor tags
 the repo owner on both the issue and the PR so the single highest-authority
-maintainer gets a direct GitHub notification. Accepted issues are also re-queued automatically
+maintainer gets a direct GitHub notification. Once that maintainer merges the
+handoff PR, the reactor reconciler closes the source issue automatically on the
+next tick instead of leaving the issue stranded in `waiting-maintainer`.
+Accepted issues are also re-queued automatically
 if their open PR becomes unmergeable due to merge conflicts, and the reactor
 also sweeps all open `openreactor/issue-*` PRs each tick so conflicted follow-up
 branches get re-claimed even when the issue itself is already closed. The

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -619,11 +619,15 @@ class Reactor {
         continue;
       }
 
-      if (!labels.has(this.config.acceptedLabel)) {
+      const accepted = labels.has(this.config.acceptedLabel);
+      const waitingMaintainer = labels.has(MAINTAINER_ACTION_REQUIRED_LABEL);
+      if (!accepted && !waitingMaintainer) {
         continue;
       }
 
-      const branchName = issueRuntimePaths(this.config, issue.number).branchName;
+      const paths = issueRuntimePaths(this.config, issue.number);
+      const record = await readRunRecord(paths);
+      const branchName = record?.branchName?.trim() || paths.branchName;
       const pullRequest = await this.github.findPullRequestByBranch(branchName, "all");
       if (!pullRequest) {
         continue;
@@ -638,6 +642,8 @@ class Reactor {
         issue.number,
         `OpenReactor marked this issue complete because ${pullRequest.html_url} was merged.`
       );
+      await this.github.removeLabel(issue.number, this.config.acceptedLabel);
+      await this.github.removeLabel(issue.number, MAINTAINER_ACTION_REQUIRED_LABEL);
       await this.github.closeIssue(issue.number, "completed");
     }
   }


### PR DESCRIPTION
## Summary
- treat merged maintainer-handoff PRs as terminal success during issue reconciliation
- remove stale `maintainer-action-required`/`accepted` labels before closing the source issue
- document that manual maintainer merges should auto-finalize the source issue on the next reactor tick

## Verification
- bun run check
- restarted local openreactor and mainthesis instances
- confirmed https://github.com/cadam17/mainthesis/issues/22 auto-closed after the fix landed locally and the reactor ticked
