### PR TITLE
Align product spec and agent doc routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,4 +14,26 @@ Repo notes:
 
 - This is an open source repo. Never commit secrets, credentials, or private tokens.
 - Keep durable learnings in the shared docs instead of leaving them only in one run.
+- When implementation changes shipped product behavior, workflow capabilities, or current limitations, update `PRODUCT_SPEC.md` in the same change. Keep the spec explicit about what is live now versus what is still planned or deferred.
 - For issue-loop work, prefer the helper commands exposed by `bun run reactor:tool`.
+
+Documentation roles:
+
+- `PRODUCT_SPEC.md`: current shipped product and workflow behavior, plus clearly marked planned/deferred work
+- `ROADMAP.md`: current priorities and sequencing of future work
+- `MEMORY.md`: durable decisions, learned constraints, and lessons worth carrying forward
+- `README.md`: public-facing overview, setup, and usage
+- `UI_SYSTEM.md`: standing visual and UI implementation rules
+- `prompts/`: standing autonomous workflow behavior for triage, planning, implementation, and UI work
+
+Documentation update checklist for non-trivial changes:
+
+- If shipped behavior, workflow capability, or a current limitation changed: update `PRODUCT_SPEC.md`
+- If priorities or sequencing changed: update `ROADMAP.md`
+- If a durable decision or lesson was learned: update `MEMORY.md`
+- If public usage, setup, or operator workflow changed: update `README.md`
+- If standing UI rules changed: update `UI_SYSTEM.md`
+- If standing issue-loop behavior changed: update the relevant file in `prompts/`
+
+Before finishing non-trivial work, do a docs audit and decide which of the
+files above needed updates. Do not leave the decision implicit.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,5 +1,20 @@
 # Product Memory
 
+## 2026-03-23
+
+- Decision: treat `PRODUCT_SPEC.md` as both the current-state product source of
+  truth and the near-term plan, with explicit separation between shipped and
+  planned behavior.
+  Reason: agents had started shipping meaningful capability changes without
+  updating the spec, which made the written product picture lag the code and
+  blurred the line between what is live now and what remains aspirational.
+
+- Decision: require a documentation-routing audit as part of non-trivial
+  autonomous implementation work.
+  Reason: telling agents to "update docs" is too vague. They work better when
+  the repo says which file owns which kind of truth and when each file must be
+  updated.
+
 ## 2026-03-09
 
 - Decision: treat GitHub issues as the initial system of record.

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -1,4 +1,14 @@
-# OpenReactor — Product Spec (v0.2)
+# OpenReactor — Product Spec (v0.3)
+
+## 0) How To Read This Spec
+This spec serves two jobs:
+
+- describe the current implemented product and workflow
+- describe planned direction where it is explicitly marked as planned, deferred, or an open question
+
+Current implemented behavior is the primary source of truth. Planned sections
+should shape future work, but they should not be mistaken for something that is
+already shipped.
 
 ## 1) Vision
 OpenReactor is a self-building software platform where users propose features, and autonomous coding agents evaluate, implement, and deploy accepted changes.
@@ -32,15 +42,21 @@ A request should be rejected/deferred if:
 - it significantly diverges from current product direction.
 
 ## 4) User Experience (MVP)
-1. User submits feature request in web form.
-2. System creates GitHub issue using structured template.
+1. User submits a feature request through the website's lightweight intake form.
+   The current intake surface is intentionally simple: one request field,
+   desired scope, and optional reference images.
+2. System converts that submission into a structured GitHub issue template.
+   When GitHub API-backed intake is unavailable, it can fall back to a GitHub
+   issue creation redirect instead of dropping the request.
 3. Request enters the reactor queue and is claimed with a GitHub label.
 4. Lightweight triage classifies surface sensitivity and evidence strength, then decides whether to `reject`, `bank`, or dispatch the request.
 5. Ongoing issue discussion can refine the request; banked, paused, or previously rejected issues may be reconsidered when later comments materially change the task or explicitly call OpenReactor back in.
 6. If dispatched, an issue agent decides whether the request should be `accepted`, `rejected`, or decomposed into smaller follow-up issues.
 7. Decomposed follow-up issues may be linked with GitHub-native dependencies when one child task truly blocks another. Independent child tasks should remain parallelizable.
-7. If accepted, the issue agent may reinterpret the request and create the best product change, then open a branch + PR.
-8. On merge to `main`, the website deploys automatically.
+8. If accepted, the issue agent may reinterpret the request and create the best product change, then open a branch + PR.
+9. If the remaining step is maintainer-only, the run may pause in a maintainer handoff state with an open PR and explicit continuation instructions.
+10. Clean accepted PRs may be merged automatically by the reactor or watchdog, depending on repository capabilities and current runtime state.
+11. On merge to `main`, the website deploys automatically.
 
 ## 5) System Architecture (MVP)
 - Frontend: public website for request intake and queue visibility
@@ -50,9 +66,9 @@ A request should be rejected/deferred if:
 - OpenReactor Autonomous Test Run: a deliberate automated canary issue that
   exercises the issue-to-PR loop end to end so workflow regressions are caught
   through a real run
-- OpenReactor status service: machine-local read-only metadata endpoint that exposes active-agent and blocker state to the website without giving the website direct control over the local runtime
+- OpenReactor status service: machine-local read-only metadata endpoint that exposes intake, triage/planning, execution, retry, blocked, and completed pipeline metadata to the website without giving the website direct control over the local runtime
 - GitHub integration: issues, labels, comments, branches, PRs, merge state
-- Persistence (current): GitHub for durable workflow state, local `.openreactor/` files for transient run state
+- Persistence (current): GitHub for durable workflow state, local `.openreactor/` files for transient run state such as run records, live snapshots, watchdog state, archives, and repo-local steering files
 - Persistence (planned): application database for website/backend features that require stored data
 
 ## 6) Data Model (MVP)
@@ -87,6 +103,12 @@ Final issue outcomes are:
 Internal run outcomes may also include:
 - `retry`
 - `decomposed`
+- `bank`
+
+Workflow-visible execution states may also include:
+- `banked`
+- `waiting-maintainer`
+- `failed`
 
 Agent behavior requirements:
 - derive whether the issue is steering or market feedback from GitHub repo
@@ -98,6 +120,9 @@ Agent behavior requirements:
 - if accepted from the steering lane, preserve explicit scope unless a hard
   blocker requires decomposition or human handoff
 - maintain issue comments/labels, testing notes, and PR linkage as part of the run
+- enforce minimum acceptance evidence for shipped work, including a real branch,
+  a real PR, and at least one passing reported check
+- require browser-verification evidence before accepting UI work
 
 ## 7.1) Canonical GitHub Support Signal
 
@@ -164,9 +189,13 @@ Dashboard should show:
 - latest product memory updates
 
 Current state:
-- only the public request queue is implemented
-- a first live OpenReactor metadata feed is available for website-side visualization
-- the rest of the observability surface is still pending
+- the public request queue is implemented
+- the website also ships a richer live OpenReactor surface showing pipeline
+  stages, service health, active agents, retries, blocked work, and recent
+  completed runs
+- the website ships a contributor leaderboard derived from merged PRs
+- accepted/rejected aggregate rates, PR cycle-time reporting, deployment
+  success/failure reporting, and memory-update reporting are still pending
 
 ## 12) Non-goals (MVP)
 - Full autonomy across infrastructure migrations
@@ -188,24 +217,45 @@ Current state:
 - Which changes require human approval despite autonomy?
 - How should roadmap priorities be updated over time?
 
-## 15) Current MVP Cutline
+## 15) Current Shipped State And MVP Cutline
 
-As of March 9, 2026, the implementation target is intentionally narrower than
-the full product vision.
+As of March 23, 2026, the implementation target is still intentionally narrower
+than the full product vision, but the code has moved materially beyond the
+original March 9 cutline.
 
 What is already live:
 
 1. a live website,
-2. a structured feature request form,
-3. GitHub issue creation from that form,
-4. a public queue view of submitted requests,
-5. and a first local `reactor/` loop for autonomous issue processing.
-6. and a local watchdog layer that supervises the reactor and stalled issue handling.
+2. a lightweight intake form that is transformed into a structured GitHub issue,
+3. GitHub issue creation from that form, with GitHub redirect fallback when
+   API-backed intake is unavailable,
+4. optional signed-in GitHub attribution for submissions and support actions,
+5. optional reference-image upload support for intake,
+6. a public queue view of submitted requests,
+7. browser-local "My requests" tracking for submissions made from the current
+   browser,
+8. a contributor leaderboard based on merged PRs,
+9. a live OpenReactor website view of intake and local runtime metadata,
+10. a local `reactor/` loop for autonomous issue processing,
+11. discussion-triggered reconsideration of banked, paused, or previously
+    rejected issues,
+12. decomposition into GitHub-native child issues with dependency edges when
+    work must be sequenced,
+13. accepted-run validation that requires a real branch, a real PR, and passing
+    reported checks,
+14. accepted PR reconciliation and merge-state handling,
+15. maintainer-handoff support for maintainer-only continuation steps,
+16. a local watchdog layer that supervises the reactor, stalled issue handling,
+    queue deadlocks, and some OpenReactor self-repair cases,
+17. and an OpenReactor Autonomous Test Run command for deliberate end-to-end
+    canary verification.
 
 The following are still deferred:
 
-- reliable end-to-end PR creation on real issues,
-- PR follow-up and merge-state handling,
 - deployment health tracking,
+- incident issue creation from deployment failures,
+- accepted/rejected aggregate metrics in the public site,
+- PR cycle-time reporting in the public site,
+- latest product-memory reporting in the public site,
 - application-backed stored data features for the website/backend,
-- and a full transparency dashboard.
+- and richer product features that genuinely require a separate durable backend.

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -7,13 +7,14 @@ You are the autonomous agent for one GitHub issue.
 1. Read the OpenReactor engine's `product-context.md` prompt file provided in your run instructions.
 2. Read the OpenReactor engine's `quality-gates.md` prompt file provided in your run instructions.
 3. Read the OpenReactor engine's `CONSTITUTION.md`.
-4. Read the repo-local product constitution under `.openreactor/repo/` when present, otherwise `PRODUCT_CONSTITUTION.md`, and read `OPENREACTOR_WORKFLOW.md`.
-5. If you touch UI, read the repo-local UI system file when present, otherwise `UI_SYSTEM.md`, before editing.
-6. Read the issue context file provided in the run directory.
-7. If the issue context lists reference images, inspect them before making implementation decisions.
-8. Read `progress.md` if it already exists.
-9. If `plan.json` exists, use it. If not, create it before coding.
-10. Prefer the OpenReactor helper command exposed at `$OPENREACTOR_ENGINE_TOOL` when it makes the workflow more reliable.
+4. Read the repo-local product spec, roadmap, memory, and README under `.openreactor/repo/` when present, otherwise read `PRODUCT_SPEC.md`, `ROADMAP.md`, `MEMORY.md`, and `README.md`.
+5. Read the repo-local product constitution under `.openreactor/repo/` when present, otherwise `PRODUCT_CONSTITUTION.md`, and read `OPENREACTOR_WORKFLOW.md`.
+6. If you touch UI, read the repo-local UI system file when present, otherwise `UI_SYSTEM.md`, before editing.
+7. Read the issue context file provided in the run directory.
+8. If the issue context lists reference images, inspect them before making implementation decisions.
+9. Read `progress.md` if it already exists.
+10. If `plan.json` exists, use it. If not, create it before coding.
+11. Prefer the OpenReactor helper command exposed at `$OPENREACTOR_ENGINE_TOOL` when it makes the workflow more reliable.
 
 ## Your Authority
 
@@ -75,10 +76,37 @@ You are the autonomous agent for one GitHub issue.
   otherwise `PRODUCT_CONSTITUTION.md` and `MEMORY.md`, `OPENREACTOR_WORKFLOW.md`,
   or related docs when you discover durable learnings that future agents
   should inherit.
+- Treat documentation maintenance as part of implementation, not optional
+  cleanup. If you change shipped behavior, workflow capability, current
+  limitations, standing UI rules, public usage, or standing issue-loop
+  behavior, update the corresponding shared docs in the same run.
 - If a feature requires a human-only step, you should prepare the code and handoff cleanly instead of pretending the task is complete.
 - Do not reject a request solely because it requires human-only setup such as
   API keys, OAuth registration, or account provisioning if the product
   direction is otherwise sound.
+
+## Documentation Routing
+
+Use the right file for the right kind of knowledge:
+
+- `PRODUCT_SPEC.md`: current shipped behavior and clearly marked planned or deferred work
+- `ROADMAP.md`: future priorities and sequencing
+- `MEMORY.md`: durable decisions, lessons, and constraints
+- `README.md`: public-facing usage, setup, and operator guidance
+- `UI_SYSTEM.md`: standing UI rules, not one-off implementation notes
+- `prompts/`: standing issue-loop behavior that future autonomous runs should follow
+
+Before you finish a non-trivial run, do a docs audit:
+
+- If shipped product behavior, workflow capability, or current limitations changed, update `PRODUCT_SPEC.md`.
+- If priorities changed, update `ROADMAP.md`.
+- If you learned something durable, update `MEMORY.md`.
+- If public-facing usage or setup changed, update `README.md`.
+- If standing UI rules changed, update `UI_SYSTEM.md`.
+- If standing autonomous behavior changed, update the relevant file in `prompts/`.
+
+Do not leave those decisions implicit. Record shared-doc updates, or the reason
+no shared-doc update was needed, in `progress.md`.
 
 ## Support And Evidence
 
@@ -133,6 +161,7 @@ bun "$OPENREACTOR_ENGINE_TOOL" ensure-plan --issue "$OPENREACTOR_ISSUE_NUMBER" -
 - what future iterations should know
 - any shared-doc updates you made or should make next
 - any required human handoff steps
+- the result of your docs audit for this run
 
 At the top of `progress.md`, maintain `## Codebase Patterns` with only durable,
 reusable learnings that future iterations should inherit quickly.
@@ -186,6 +215,7 @@ If accepted and fully complete:
 - fill the structured `considerations` field with the key public-facing
   factors and tradeoffs that shaped your decision; do not emit hidden
   chain-of-thought
+- ensure the docs audit is complete before returning `accepted`
 
 If blocked on a human-only step:
 
@@ -246,6 +276,8 @@ If more work is needed after this iteration:
 - keep `or:running`
 - do not apply `accepted` or `rejected`
 - update `plan.json`, `tasks.md`, and `progress.md`
+- update any shared docs that already became stale during this iteration rather
+  than deferring that cleanup without noting it
 - return `retry`
 
 ## Commit Attribution

--- a/prompts/planner-agent.md
+++ b/prompts/planner-agent.md
@@ -10,6 +10,9 @@ Your job is not to implement the large request directly. Your job is to:
 
 Rules:
 
+- Read the current `PRODUCT_SPEC.md`, `ROADMAP.md`, and `MEMORY.md` in the
+  target repo context before decomposing the work so you preserve the current
+  product truth and not just the aspirational direction.
 - Decompose only when the request is too large, too broad, or too multi-step for one safe implementation issue.
 - Do not reject a request solely because it may require human setup such as API keys, OAuth app registration, or external account configuration.
 - For trusted repo steering from users with actual repo access, preserve the

--- a/prompts/triage-agent.md
+++ b/prompts/triage-agent.md
@@ -9,9 +9,13 @@ implementation tool.
 Rules:
 
 - Read the OpenReactor engine prompt files and workflow docs provided in your
-  run instructions, plus the repo-local product constitution and roadmap under
-  `.openreactor/repo/` when present, otherwise `PRODUCT_CONSTITUTION.md` and
-  `ROADMAP.md`, before deciding.
+  run instructions, plus the repo-local product spec, constitution, roadmap,
+  and memory under `.openreactor/repo/` when present, otherwise
+  `PRODUCT_SPEC.md`, `PRODUCT_CONSTITUTION.md`, `ROADMAP.md`, and `MEMORY.md`,
+  before deciding.
+- Treat `PRODUCT_SPEC.md` as the current-state product truth and `ROADMAP.md`
+  as the future-priorities document. Do not confuse a planned direction with
+  something that is already shipped.
 - Classify the target surface as `main`, `playground`, or `openreactor-core`.
 - Treat the issue body and the recent issue discussion together as the current
   request. Comments can refine, narrow, or materially update the task.

--- a/prompts/ui-agent.md
+++ b/prompts/ui-agent.md
@@ -5,6 +5,11 @@ Use this prompt as the frontend design skill equivalent for UI-heavy issues.
 Rules:
 
 - Read `UI_SYSTEM.md` before making visual decisions.
+- If your UI change also changes standing visual rules or reusable UI patterns,
+  update `UI_SYSTEM.md` in the same run instead of leaving the new rule only in
+  code.
+- If your UI change alters shipped product behavior or current limitations,
+  update `PRODUCT_SPEC.md` too.
 - Preserve established patterns when the current UI already has a clear visual language.
 - When making new UI, prefer intentional, distinctive choices over generic dashboard styling.
 - Treat typography, spacing, hierarchy, and motion as product decisions, not cleanup details.
@@ -19,3 +24,6 @@ Rules:
 - Check the changed surface at desktop and narrow/mobile widths before calling the issue accepted.
 - Do not add visual churn that is unrelated to the issue.
 - If the request is mostly visual or interaction-oriented, bias toward a polished result rather than the minimum literal change.
+- Before finishing non-trivial UI work, do a docs audit for `PRODUCT_SPEC.md`,
+  `UI_SYSTEM.md`, `README.md`, and `MEMORY.md` rather than assuming code alone
+  is enough.


### PR DESCRIPTION
## Summary
- update `PRODUCT_SPEC.md` to reflect the current implemented workflow and separate shipped state from planned work
- define documentation ownership and a docs-audit checklist in `AGENTS.md`
- require issue-loop prompts to read the right docs and update shared docs when behavior changes
- record the documentation-routing decision in `MEMORY.md`

## Testing
- not run (docs and prompts only)
