### PR TITLE
Update OpenReactor defaults for GPT-5.5

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,5 +1,22 @@
 # Product Memory
 
+## 2026-04-30
+
+- Decision: default OpenAI-backed Codex reactor runs now use `gpt-5.5` for
+  triage, planning, and implementation while preserving the existing
+  role-specific reasoning efforts.
+  Reason: current OpenAI guidance names `gpt-5.5` as the latest model and
+  recommends starting migrations by updating the model string while tuning
+  prompts and reasoning effort against the workflow rather than changing every
+  parameter at once.
+
+- Decision: keep OpenReactor's agent prompts outcome-first while preserving
+  the detailed product, governance, and GitHub contracts the workflow depends
+  on.
+  Reason: GPT-5.5 responds well to explicit outcomes and stopping conditions,
+  but OpenReactor still needs durable rules for acceptance, decomposition,
+  documentation, validation, and maintainer handoff.
+
 ## 2026-04-28
 
 - Decision: use the segmented concentric-ring mark with the orange core as the

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -98,6 +98,13 @@ Each run receives:
 - current issue body + labels + context
 - local run files such as `plan.json` and `progress.md`
 
+Default OpenAI-backed Codex runs currently target `gpt-5.5` for triage,
+planning, and implementation. The default reasoning efforts remain tuned by
+role: `low` for triage, `high` for planning, and `medium` for implementation.
+Operators can override those defaults with the corresponding
+`OPENREACTOR_*_MODEL` and `OPENREACTOR_*_REASONING_EFFORT` environment
+variables.
+
 Final issue outcomes are:
 - `accepted`
 - `rejected`

--- a/README.md
+++ b/README.md
@@ -403,6 +403,12 @@ Useful environment variables:
 - `OPENREACTOR_STATUS_PORT`
 - `OPENREACTOR_STATUS_TOKEN`
 
+OpenAI-backed Codex runs default to `gpt-5.5` for triage, planning, and
+implementation. The default reasoning effort is role-specific: `low` for
+triage, `high` for planning, and `medium` for implementation. Override the
+model or effort variables only when a managed repo needs a measured latency,
+cost, or quality tradeoff.
+
 Leave the `*_SERVICE_TIER` variables unset unless you have a known-good tier for the installed Codex CLI and account. The default reactor behavior is to omit `service_tier` entirely.
 
 For OpenReactor's current repo size, a small-team default of

--- a/ops/reactor.env.example
+++ b/ops/reactor.env.example
@@ -30,15 +30,15 @@ GITHUB_APP_PRIVATE_KEY=
 # OPENREACTOR_MAX_ITERATIONS_PER_ISSUE=8
 # OPENREACTOR_MAX_START_FAILURES_PER_ISSUE=3
 # OPENREACTOR_PAUSED_LABEL=or:paused
-# OPENREACTOR_TRIAGE_MODEL=gpt-5.3-codex-spark
+# OPENREACTOR_TRIAGE_MODEL=gpt-5.5
 # OPENREACTOR_TRIAGE_REASONING_EFFORT=low
 # Optional. Leave unset unless you have a known-good service tier for this Codex build/account.
 # OPENREACTOR_TRIAGE_SERVICE_TIER=
-# OPENREACTOR_PLANNER_MODEL=gpt-5.4
+# OPENREACTOR_PLANNER_MODEL=gpt-5.5
 # OPENREACTOR_PLANNER_REASONING_EFFORT=high
 # Optional. Leave unset unless you have a known-good service tier for this Codex build/account.
 # OPENREACTOR_PLANNER_SERVICE_TIER=
-# OPENREACTOR_AGENT_MODEL=gpt-5.4
+# OPENREACTOR_AGENT_MODEL=gpt-5.5
 # OPENREACTOR_AGENT_REASONING_EFFORT=medium
 # Optional. Leave unset unless you have a known-good service tier for this Codex build/account.
 # OPENREACTOR_AGENT_SERVICE_TIER=

--- a/packages/factory-floor/demo/mock-data.json
+++ b/packages/factory-floor/demo/mock-data.json
@@ -208,7 +208,7 @@
         "currentNodeId": "execution",
         "currentItemId": "openreactor:issue:295",
         "provider": "codex",
-        "model": "gpt-5.3-codex-spark",
+        "model": "gpt-5.5",
         "startedAt": "2026-03-26T09:30:00.000Z",
         "lastHeartbeatAt": "2026-03-26T09:59:00.000Z",
         "extensions": { "openreactor": { "issueNumber": 295, "toolName": "spawn_codex_issue_agent", "toolLabel": "Codex issue agent", "iteration": 1 } }

--- a/packages/factory-floor/demo/simulation.ts
+++ b/packages/factory-floor/demo/simulation.ts
@@ -43,9 +43,9 @@ const ISSUE_TITLES = [
 ];
 
 const AGENT_TEMPLATES = [
-  { role: "general", label: "Codex Agent", provider: "codex", model: "gpt-5.3-codex-spark" },
+  { role: "general", label: "Codex Agent", provider: "codex", model: "gpt-5.5" },
   { role: "ui", label: "Claude UI Agent", provider: "claude", model: "claude-sonnet-4-6" },
-  { role: "planning", label: "Codex Planner", provider: "codex", model: "gpt-5.3-codex-spark" },
+  { role: "planning", label: "Codex Planner", provider: "codex", model: "gpt-5.5" },
 ];
 
 type Stage = "intake" | "triage-planning" | "execution" | "waiting" | "completed" | "decomposed" | "rejected";
@@ -417,7 +417,7 @@ function buildPayload(sim: SimState): AutomationStatusPayload {
       currentNodeId: "triage-planning",
       currentItemId: `openreactor:issue:${issue.number}`,
       provider: "codex",
-      model: "gpt-5.3-codex-spark",
+      model: "gpt-5.5",
       startedAt: now,
       lastHeartbeatAt: now,
       extensions: {
@@ -440,7 +440,7 @@ function buildPayload(sim: SimState): AutomationStatusPayload {
       currentNodeId: "triage-planning",
       currentItemId: `openreactor:issue:${issue.number}`,
       provider: "codex",
-      model: "gpt-5.3-codex-spark",
+      model: "gpt-5.5",
       startedAt: now,
       lastHeartbeatAt: now,
       extensions: {

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -2,6 +2,12 @@
 
 You are the autonomous agent for one GitHub issue.
 
+Optimize for the outcome: convert the live issue context into one of three
+clean results, `accepted`, `rejected`, or `decomposed`, with concrete evidence,
+validation, and public-facing rationale. Continue through implementation and
+verification when the scope is feasible; stop and hand off only when a real
+human-only blocker remains.
+
 ## What You Must Do First
 
 1. Read the OpenReactor engine's `product-context.md` prompt file provided in your run instructions.
@@ -15,14 +21,6 @@ You are the autonomous agent for one GitHub issue.
 9. Read `progress.md` if it already exists.
 10. If `plan.json` exists, use it. If not, create it before coding.
 11. Prefer the OpenReactor helper command exposed at `$OPENREACTOR_ENGINE_TOOL` when it makes the workflow more reliable.
-5. Read the repo-local triage policy under `.openreactor/repo/` when present, otherwise `TRIAGE_POLICY.md` if it exists.
-6. Read `OPENREACTOR_WORKFLOW.md`.
-7. If you touch UI, read the repo-local UI system file when present, otherwise `UI_SYSTEM.md`, before editing.
-8. Read the issue context file provided in the run directory.
-9. If the issue context lists reference images, inspect them before making implementation decisions.
-10. Read `progress.md` if it already exists.
-11. If `plan.json` exists, use it. If not, create it before coding.
-12. Prefer the OpenReactor helper command exposed at `$OPENREACTOR_ENGINE_TOOL` when it makes the workflow more reliable.
 
 ## Your Authority
 

--- a/prompts/planner-agent.md
+++ b/prompts/planner-agent.md
@@ -8,6 +8,10 @@ Your job is not to implement the large request directly. Your job is to:
 - break it into a small set of narrower implementation issues
 - preserve useful human-handoff details when external setup is required
 
+Optimize for the outcome: produce the smallest dependency-aware issue set that
+keeps the worthwhile scope intact and lets implementation agents work without
+re-litigating the parent request.
+
 Rules:
 
 - Read the current `PRODUCT_SPEC.md`, `ROADMAP.md`, and `MEMORY.md` in the

--- a/prompts/triage-agent.md
+++ b/prompts/triage-agent.md
@@ -6,6 +6,12 @@ Your job is not to implement anything. Your only job is to decide whether an
 issue should be rejected cheaply, banked for later, or dispatched to the best
 implementation tool.
 
+Optimize for the outcome: make the cheapest defensible routing decision that
+preserves valid product work, protects maintainer-controlled surfaces, and
+gives the next agent enough context to continue without re-triaging from
+scratch. Stop once you have enough evidence to choose `reject`, `bank`, or a
+dispatch target.
+
 Rules:
 
 - Read the OpenReactor engine prompt files and workflow docs provided in your

--- a/reactor/config.ts
+++ b/reactor/config.ts
@@ -49,6 +49,7 @@ export interface OrchestratorConfig {
 }
 
 const ENGINE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_OPENAI_MODEL = "gpt-5.5";
 
 export function loadConfig(repoRoot = resolveManagedRepoRoot()): OrchestratorConfig {
   const engineRoot = clean(process.env.OPENREACTOR_ENGINE_ROOT) || ENGINE_ROOT;
@@ -87,20 +88,20 @@ export function loadConfig(repoRoot = resolveManagedRepoRoot()): OrchestratorCon
     githubAppClientId: clean(valueOf("GITHUB_APP_CLIENT_ID", localEnv)),
     githubAppInstallationId: clean(valueOf("GITHUB_APP_INSTALLATION_ID", localEnv)),
     githubAppPrivateKey: clean(valueOf("GITHUB_APP_PRIVATE_KEY", localEnv)).replace(/\\n/g, "\n"),
-    triageModel: clean(process.env.OPENREACTOR_TRIAGE_MODEL) || "gpt-5.3-codex-spark",
+    triageModel: clean(process.env.OPENREACTOR_TRIAGE_MODEL) || DEFAULT_OPENAI_MODEL,
     triageReasoningEffort:
       clean(process.env.OPENREACTOR_TRIAGE_REASONING_EFFORT) || "low",
     triageServiceTier: clean(process.env.OPENREACTOR_TRIAGE_SERVICE_TIER),
     plannerModel:
       clean(process.env.OPENREACTOR_PLANNER_MODEL) ||
       clean(process.env.OPENREACTOR_AGENT_MODEL) ||
-      "gpt-5.4",
+      DEFAULT_OPENAI_MODEL,
     plannerReasoningEffort:
       clean(process.env.OPENREACTOR_PLANNER_REASONING_EFFORT) || "high",
     plannerServiceTier:
       clean(process.env.OPENREACTOR_PLANNER_SERVICE_TIER) ||
       clean(process.env.OPENREACTOR_AGENT_SERVICE_TIER),
-    agentModel: clean(process.env.OPENREACTOR_AGENT_MODEL) || "gpt-5.4",
+    agentModel: clean(process.env.OPENREACTOR_AGENT_MODEL) || DEFAULT_OPENAI_MODEL,
     agentReasoningEffort:
       clean(process.env.OPENREACTOR_AGENT_REASONING_EFFORT) || "medium",
     agentServiceTier: clean(process.env.OPENREACTOR_AGENT_SERVICE_TIER),


### PR DESCRIPTION
## Summary
- Updates OpenAI-backed Codex defaults to gpt-5.5 for triage, planning, and implementation
- Adds outcome-first GPT-5.5 prompt guidance while preserving existing workflow contracts
- Refreshes operator docs, product spec, memory, and factory-floor demo model metadata

## Validation
- bun run check
- git diff --check