### PR TITLE
Add Genesis and Codex UI workflows

### DIFF
--- a/.openreactor/repo/MEMORY.md
+++ b/.openreactor/repo/MEMORY.md
@@ -1,20 +1,14 @@
 # Memory
 
-Record durable product and workflow learnings here.
+## 2026-05-04
 
-## Bootstrap context
+- Decision: Project Genesis should be handled by an external ChatGPT/Codex
+  agent and expressed as OpenReactor-ready repo-local state, not run as a live
+  conversational mode inside OpenReactor.
+  Reason: new-product planning needs real-time clarification and pushback,
+  while OpenReactor is optimized for asynchronous backend execution from
+  committed product docs and GitHub issues.
 
-OpenReactor is an agentic harness that allows software products to evolve on
-their own.
-
-The core idea is simple: the full product lifecycle can now be automated, not
-just the code-writing step. Requests can enter a system, get judged, get turned
-into real product work, move through branches and pull requests, deploy, and
-feed their learnings back into the system again.
-
-## Decisions
-
-- Add dated decisions with a short reason so future agents inherit them.
 - Decision: in the `openreactor` repo, large feedback-lane feature requests
   should require stronger validation before dispatch.
   Reason: public product feedback should still shape the website and
@@ -33,3 +27,18 @@ feed their learnings back into the system again.
   unrelated large features.
   Reason: those surfaces are product-defining and should only move
   incrementally from feedback unless stronger validation or steering exists.
+- Decision: frontend/design-heavy issues should route to Codex UI, not Claude
+  UI. The workflow should first create a Codex-generated design image and
+  brief with `xhigh` reasoning, then feed the image into the implementation
+  Codex agent.
+  Reason: visual implementation quality benefits from a concrete image target,
+  and Codex is the active frontend agent path for image-attached UI work.
+- Decision: keep stack-specific execution guidance in `STACK_WORKFLOWS.md`.
+  Reason: full-stack app building needs stronger per-surface workflows for
+  frontend, backend/API, data, infrastructure, mobile, AI, ingestion, security,
+  and payments than a single generic implementation prompt can provide.
+- Decision: managed-repo issue startup should run workspace policy provision
+  hooks and forward policy env into agent runs.
+  Reason: product builds that need dependencies, local services, or emulators
+  should fail early and visibly during provisioning instead of letting the
+  implementation agent discover a half-configured workspace late.

--- a/.openreactor/repo/PRODUCT_CONSTITUTION.md
+++ b/.openreactor/repo/PRODUCT_CONSTITUTION.md
@@ -1,15 +1,44 @@
-# Product Constitution
+# OpenReactor Product Constitution
 
 ## Mission
 
-State what this product is meant to optimize for.
+OpenReactor should make the product lifecycle itself more autonomous: requests
+enter through public or GitHub-native channels, get judged against product
+state, become scoped implementation work, ship through PRs, and feed durable
+learnings back into the repo.
 
-## Standing rules
+## Standing Rules
 
-- List the durable product rules agents should treat as binding.
-- Note what kinds of requests should be rejected.
-- Note which surfaces are high-sensitivity.
+- Keep the public product focused on explaining and operating the autonomous
+  issue-to-PR loop.
+- Preserve the distinction between community-shapeable product surfaces and
+  maintainer-controlled OpenReactor core behavior.
+- Prefer small, reviewable changes that improve the request, visibility,
+  playground, or managed-repo workflow.
+- Treat Project Genesis as an external ChatGPT/Codex collaboration that
+  produces repo-local state before new-product implementation begins.
+- Use stack-specific workflows for specialized work instead of applying one
+  generic implementation pattern to every surface.
+- Route frontend/design-heavy issues through the Codex UI workflow with a
+  generated design image and brief before implementation.
+- Never commit secrets, private credentials, production tokens, or private
+  customer data.
 
-## Human handoff rules
+## Reject Or Bank
 
-- Document what should happen when a maintainer-only step is required.
+Reject requests that are illegal, unsafe, malicious, deceptive, or require
+publishing large copyrighted third-party content without clear rights.
+
+Bank feedback-lane requests when they are directionally plausible but too weak
+for the sensitivity of the affected surface, too broad for the current stage,
+or need more evidence before reshaping a high-sensitivity product area.
+
+## Human Handoff
+
+Human handoff is required for production secrets, paid service accounts, OAuth
+registration, DNS, production infrastructure approval, app-store signing,
+payment account setup, and any other maintainer-only external action.
+
+Agents may prepare code, documentation, configuration, and PRs for those paths,
+but they must not claim the feature is fully live until the human-only step is
+complete.

--- a/.openreactor/repo/PRODUCT_SPEC.md
+++ b/.openreactor/repo/PRODUCT_SPEC.md
@@ -19,6 +19,19 @@ feed their learnings back into the system again.
 - Visitors can browse `/playground/` for low-sensitivity experiments and odd
   side pages, including joke-forward features such as the goon material
   recommender, without those experiments redefining the main intake surface.
+- Product owners can run an external ChatGPT/Codex Project Genesis
+  collaboration before starting OpenReactor on a new repo. Genesis produces
+  OpenReactor-ready `.openreactor/repo/` state and a small initial backlog;
+  the reactor then consumes that committed state as its backend execution
+  input.
+- UI-heavy issues route through the Codex UI workflow: Codex first creates a
+  generated design image and brief with `xhigh` reasoning, then the
+  implementation Codex agent receives that image along with issue-provided
+  references.
+- Specialized work should follow the stack workflow profiles in
+  `STACK_WORKFLOWS.md`, including backend/API, data model, infrastructure,
+  mobile, AI/agent, data ingestion, security/auth/payments, and full-stack app
+  slices.
 
 Highest-sensitivity flows:
 
@@ -36,3 +49,10 @@ Highest-sensitivity flows:
   low-risk and avoid explicit or unsafe content on the main intake surface.
 - Public pages should stay lightweight and static-first unless a request
   clearly needs backend or runtime integration.
+- OpenReactor should not become the real-time planning interface for Project
+  Genesis. Keep interactive product discovery in the external Codex
+  conversation and hand the reactor durable repo-local state once the direction
+  is concrete.
+- Workspace policy provision hooks now run before implementation agents start
+  on managed-repo issue worktrees. Secrets still belong outside committed
+  policy files.

--- a/.openreactor/repo/README.md
+++ b/.openreactor/repo/README.md
@@ -1,33 +1,21 @@
-# openreactor
+# openreactor Repo State
 
-This directory contains the repo-local OpenReactor state for this product.
+This directory is the product steering layer for the OpenReactor product.
 
-OpenReactor's shared engine lives outside this repo-local state. What belongs here is the product-specific material that future issue agents should inherit:
+OpenReactor itself is the shared autonomous issue-to-PR execution engine. This
+repo's product state describes the public OpenReactor website, request intake,
+queue visibility, playground surface, and the maintainer-controlled engine
+workflow that those product surfaces explain.
 
-- what this repo is for
-- what counts as a good change
-- what to avoid
-- how triage should classify and route requests for this product
-- roadmap direction
-- durable memory from past work
+Agents should treat these files as the repo-local source of product truth:
 
-Treat these files as the product steering layer for this repository.
+- `PRODUCT_SPEC.md`: current OpenReactor product behavior and limitations
+- `PRODUCT_CONSTITUTION.md`: durable product rules
+- `TRIAGE_POLICY.md`: request classification and routing rules
+- `ROADMAP.md`: current sequencing
+- `MEMORY.md`: durable decisions and lessons
 
-## Bootstrap signals
-
-### README signal
-
-OpenReactor is an agentic harness that allows software products to evolve on
-their own.
-
-The core idea is simple: the full product lifecycle can now be automated, not
-just the code-writing step. Requests can enter a system, get judged, get turned
-into real product work, move through branches and pull requests, deploy, and
-feed their learnings back into the system again.
-
-### Issue signal
-
-- #192 [Request] Add/ auto-generate new features every 24 hours and upload to the website
-  <!-- openreactor:feature-request --> ## Summary Add/ auto-generate new features every 24 hours and upload to the website ## Problem Add/ auto-generate new features every 24 hours and upload to the website. ## Desired Ou…
-- #233 [Request] add the ability to select a component and request feature changes directly from the ui of the specific compnent
-  <!-- openreactor:feature-request --> ## Summary add the ability to select a component and request feature changes directly from the ui of the specific compnent ## Problem add the ability to select a component and reques…
+For new managed products, this directory should usually be created by a Project
+Genesis conversation with a ChatGPT/Codex agent before OpenReactor starts
+implementation. Genesis writes concrete product steering files and a small
+initial backlog; the reactor then consumes that committed state.

--- a/.openreactor/repo/ROADMAP.md
+++ b/.openreactor/repo/ROADMAP.md
@@ -2,7 +2,16 @@
 
 ## Near-term priorities
 
-- Add the current priorities for this repo.
+- Keep OpenReactor focused as the backend issue-to-PR execution loop.
+- Treat Project Genesis as an external ChatGPT/Codex collaboration that
+  produces `.openreactor/repo/` state and a small initial implementation
+  backlog for new products.
+- Improve readiness checks for repo-local product state so agents do not build
+  from vague or placeholder docs.
+- Continue strengthening managed-repo operation, especially workspace
+  provisioning, deployment verification, and human handoff paths.
+- Use the Codex UI design-image workflow for frontend work and keep expanding
+  stack-specific workflows where specialized guidance improves agent outcomes.
 
 ## Signals from existing issues
 
@@ -13,4 +22,8 @@
 
 ## Not now
 
-- Add ideas that are explicitly out of scope for the current stage.
+- Do not build a real-time Genesis chat interface into the reactor itself.
+- Do not ask OpenReactor to implement a whole new product from one giant issue
+  without committed repo-local Genesis output first.
+- Do not reintroduce Claude as the frontend-specialized implementation path
+  unless the image-input and design-prepass workflow is explicitly redesigned.

--- a/.openreactor/repo/TRIAGE_POLICY.md
+++ b/.openreactor/repo/TRIAGE_POLICY.md
@@ -43,6 +43,12 @@ behavior.
 
 - Do not reject a request solely because it implies substantial backend or
   implementation work.
+- Route frontend/design-heavy requests to the Codex UI workflow so a generated
+  design image and brief are created before implementation.
+- Route large but directionally valid full-stack work to planning when it needs
+  decomposition across UI, backend/API, data model, infrastructure, mobile,
+  AI/agent behavior, data ingestion, security/auth/payments, or deployment
+  slices.
 - Reject requests that would publish, reproduce, translate, or route large
   amounts of copyrighted third-party text, media, or other protected content
   without clear rights to do so. Those are not refinement problems; they are

--- a/AUTOMATION_STATUS_EXAMPLE.json
+++ b/AUTOMATION_STATUS_EXAMPLE.json
@@ -113,7 +113,7 @@
           "openreactor": {
             "issueNumber": 201,
             "branchName": "openreactor/issue-201",
-            "toolLabel": "Claude UI agent"
+            "toolLabel": "Codex UI agent"
           }
         }
       },
@@ -137,12 +137,12 @@
       {
         "id": "openreactor:actor:201",
         "kind": "agent",
-        "label": "Claude UI agent",
+        "label": "Codex UI agent",
         "role": "ui",
         "status": "working",
         "currentNodeId": "execution",
         "currentItemId": "openreactor:issue:201",
-        "provider": "claude",
+        "provider": "codex",
         "startedAt": "2026-03-25T04:45:00.000Z",
         "lastHeartbeatAt": "2026-03-25T04:59:00.000Z"
       }
@@ -217,7 +217,7 @@
         "level": "info",
         "subjectType": "item",
         "subjectId": "openreactor:issue:201",
-        "message": "Claude UI agent is actively iterating on the queue cards."
+        "message": "Codex UI agent is actively iterating on the queue cards."
       }
     ]
   },

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -77,6 +77,8 @@ Read the relevant document for the surface you are working on:
 
 - [PRODUCT_CONSTITUTION.md](/home/ray/projects/openreactor/PRODUCT_CONSTITUTION.md)
 - [OPENREACTOR_WORKFLOW.md](/home/ray/projects/openreactor/OPENREACTOR_WORKFLOW.md)
+- [GENESIS_WORKFLOW.md](/home/ray/projects/openreactor/GENESIS_WORKFLOW.md)
+- [STACK_WORKFLOWS.md](/home/ray/projects/openreactor/STACK_WORKFLOWS.md)
 
 If a change crosses the boundary, default to the stricter OpenReactor rules
 unless the maintainer has explicitly steered otherwise.

--- a/FACTORY_FLOOR_SPEC.md
+++ b/FACTORY_FLOOR_SPEC.md
@@ -355,7 +355,7 @@ Iteration badge and status light.
     <div class="ff-actor-bay__workspace"><!-- active token --></div>
   </div>
   <div class="ff-actor-bay__nameplate">
-    <span class="ff-actor-bay__name">Claude UI agent</span>
+    <span class="ff-actor-bay__name">Codex UI agent</span>
     <span class="ff-actor-bay__task">#201 Polish queue cards</span>
   </div>
   <div class="ff-actor-bay__status-light"></div>

--- a/GENESIS_WORKFLOW.md
+++ b/GENESIS_WORKFLOW.md
@@ -1,0 +1,220 @@
+# Project Genesis Workflow
+
+Project Genesis is the interactive product-design phase that happens before
+OpenReactor begins autonomous implementation work on a new product.
+
+OpenReactor itself is not the right interface for this phase. The reactor is a
+backend execution loop that consumes committed product state and GitHub issues.
+It is intentionally asynchronous, GitHub-native, and not optimized for live
+back-and-forth clarification with a human.
+
+The Genesis phase should usually be run with a ChatGPT/Codex agent in direct
+collaboration with the product owner. That agent's job is to turn an initial
+product prompt into OpenReactor-ready repo state and a small implementation
+backlog.
+
+## Boundary
+
+Genesis agent responsibilities:
+
+- clarify the product idea through conversation
+- challenge weak assumptions or over-broad scope
+- decide the smallest coherent v0 product nucleus
+- choose or document the intended stack and platform targets
+- identify human-only setup steps, secrets, accounts, and infrastructure
+- write repo-local product steering files under `.openreactor/repo/`
+- optionally create an initial implementation issue backlog
+
+OpenReactor responsibilities after Genesis:
+
+- read the committed repo-local product state
+- triage future GitHub issues against that state
+- decompose oversized implementation work when needed
+- create branches, pull requests, verification evidence, and handoffs
+- keep product memory and workflow docs current as implementation changes land
+
+OpenReactor should not be treated as the live interview surface for Genesis.
+If the product direction is still being negotiated, keep it in the Codex
+conversation until the output is concrete enough to commit.
+
+## Required Outputs
+
+A completed Genesis pass should produce these files:
+
+- `.openreactor/repo/README.md`
+- `.openreactor/repo/PRODUCT_SPEC.md`
+- `.openreactor/repo/PRODUCT_CONSTITUTION.md`
+- `.openreactor/repo/TRIAGE_POLICY.md`
+- `.openreactor/repo/ROADMAP.md`
+- `.openreactor/repo/MEMORY.md`
+
+It may also produce:
+
+- `UI_SYSTEM.md` or `.openreactor/repo/UI_SYSTEM.md` for products with rendered UI
+- `workspace-policy.json` or `.openreactor/repo/workspace-policy.json`
+- stack-specific notes or setup docs guided by `STACK_WORKFLOWS.md`
+- initial GitHub issues for the first implementation slices
+- setup documentation for required external services
+
+## Product Spec Contract
+
+`.openreactor/repo/PRODUCT_SPEC.md` should describe the current intended
+product, not an unbounded wish list.
+
+It should include:
+
+- product summary
+- target users and primary jobs-to-be-done
+- supported platforms, such as web, mobile, backend service, or infrastructure
+- core workflows for v0
+- explicit v0 scope
+- what is planned later
+- what is explicitly deferred
+- data model and integration assumptions when relevant
+- current limitations that implementation agents must not pretend are solved
+
+For a brand-new repo, "current" means the approved Genesis target state that
+OpenReactor should start building toward.
+
+## Product Constitution Contract
+
+`.openreactor/repo/PRODUCT_CONSTITUTION.md` should define durable product
+rules.
+
+It should include:
+
+- product mission
+- non-negotiable product principles
+- safety, privacy, legal, and content boundaries
+- what kinds of requests should be rejected
+- what kinds of requests should be banked for later
+- human handoff rules for secrets, accounts, paid services, deployment access,
+  app-store work, infrastructure approval, or other maintainer-only actions
+
+## Triage Policy Contract
+
+`.openreactor/repo/TRIAGE_POLICY.md` should tell OpenReactor how to classify
+future requests for this product.
+
+It should include:
+
+- surface map for `main`, `playground`, and `openreactor-core` when applicable
+- sensitivity map for low, medium, and high-risk product areas
+- what ordinary public feedback may change
+- what only steering-lane requests may change
+- dispatch heuristics for backend, mobile, infrastructure, data ingestion, or
+  other large product-critical work
+- examples of requests that should be rejected, banked, decomposed, or
+  dispatched
+
+## Roadmap Contract
+
+`.openreactor/repo/ROADMAP.md` should sequence the first build, not just collect
+ideas.
+
+It should include:
+
+- Now: the smallest useful product nucleus
+- Next: obvious follow-on work after the nucleus is working
+- Later: larger enhancements that should not distract early implementation
+- Not now: ideas that are explicitly deferred or out of scope
+
+The "Now" section should be small enough to become a short implementation
+backlog. Genesis should avoid handing OpenReactor a giant multi-month plan as
+one undifferentiated request.
+
+## Memory Contract
+
+`.openreactor/repo/MEMORY.md` should preserve durable decisions from the
+Genesis conversation.
+
+Each decision should include:
+
+- date
+- decision
+- reason
+
+Good memory entries explain why the product is shaped a certain way, what was
+intentionally deferred, and which tradeoffs future agents should not re-litigate
+without new evidence.
+
+## Workspace Policy Contract
+
+If the product needs setup beyond the default package commands, Genesis should
+create a workspace policy file.
+
+Use `.openreactor/repo/workspace-policy.json` when the policy is product-local.
+Use root `workspace-policy.json` only for legacy repos or when the repo has not
+adopted `.openreactor/repo/` yet.
+
+The policy should document:
+
+- provision command
+- teardown command when needed
+- required non-secret environment variable defaults
+- assumptions about local services, emulators, databases, or mobile simulators
+
+Do not commit secrets. If a secret or external account is required, document it
+as a human handoff in the product constitution, roadmap, or setup docs.
+
+## Stack Workflow Contract
+
+Genesis should identify which stack workflows the product needs. Use
+`STACK_WORKFLOWS.md` as the standing menu of execution patterns.
+
+At minimum, Genesis should call out whether the initial build includes:
+
+- frontend or UI work
+- backend/API work
+- database or data model work
+- infrastructure or deployment work
+- mobile app work
+- AI/agent behavior
+- data ingestion or scraping
+- security, auth, or payments
+
+For UI-heavy products, Genesis should expect OpenReactor to use the Codex UI
+workflow: an `xhigh` reasoning design-image prepass creates a concrete UI image
+and design brief, then that image is attached to the frontend implementation
+agent.
+
+## Initial Issue Backlog Contract
+
+Genesis may create initial GitHub issues after the repo-local state is written.
+If it does, prefer 3 to 8 implementation issues.
+
+Each issue should:
+
+- be one coherent implementation slice
+- include acceptance criteria
+- name relevant product docs or roadmap items
+- call out platform, backend, mobile, or infrastructure requirements
+- include human-only setup blockers when they exist
+- avoid starting with `[Request]` unless it is going through the public intake
+  path
+- avoid using the public intake marker unless the issue truly came from that
+  path
+
+Dependencies should be used only for real blockers. Independent slices should
+remain parallelizable.
+
+## Readiness Checklist
+
+A repo is ready for OpenReactor implementation when:
+
+- the required `.openreactor/repo/` docs exist and are not placeholders
+- v0 scope is concrete enough for implementation agents to judge completion
+- high-sensitivity surfaces and steering-only areas are identified
+- setup, test, and deployment assumptions are documented
+- human-only prerequisites are explicit
+- the first implementation backlog is small, sequenced, and reviewable
+- there are no committed secrets or private credentials
+
+Use this local check before starting the reactor on a Genesis output:
+
+```bash
+bun run reactor:tool check-genesis
+```
+
+If those conditions are not met, continue the Genesis conversation instead of
+starting the reactor on vague product state.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,5 +1,15 @@
 # Product Memory
 
+## 2026-05-04
+
+- Decision: treat Project Genesis as an external ChatGPT/Codex collaboration
+  that produces OpenReactor-ready repo-local state, not as a live mode inside
+  the reactor itself.
+  Reason: Genesis needs fast back-and-forth clarification, disagreement, and
+  product judgment before implementation starts. OpenReactor is better kept as
+  the backend execution loop that consumes committed product docs and GitHub
+  issues.
+
 ## 2026-04-28
 
 - Decision: use the segmented concentric-ring mark with the orange core as the
@@ -456,9 +466,29 @@
   image input.
   Reason: markdown image links in the issue body are not a reliable substitute
   for actual multimodal input when an agent needs to inspect a UI reference or
-  other uploaded image while implementing the issue, and Claude Code can read
-  image files by local path when that directory is included in its allowed
-  scope.
+  other uploaded image while implementing the issue.
+
+- Decision: frontend/design-heavy work should use a Codex UI path rather than
+  Claude UI. That path first runs a Codex design-image prepass at `xhigh`
+  reasoning, writes a concrete design image and brief, then feeds the image to
+  the implementation Codex agent.
+  Reason: UI implementation quality improves when the agent receives a concrete
+  visual target, and the Codex frontend guidance plus multimodal image input is
+  a better fit for this workflow than the previous Claude-specialized path.
+
+- Decision: OpenReactor should keep stack-specific workflows in
+  `STACK_WORKFLOWS.md`.
+  Reason: frontend, backend, mobile, infrastructure, AI, data, security, and
+  full-stack app work have different failure modes. More specific workflow
+  profiles should improve agent performance without overloading every issue
+  prompt with every niche rule.
+
+- Decision: managed-repo issue startup should run workspace policy provision
+  hooks before spawning implementation agents, and policy env should be
+  forwarded into those agent processes.
+  Reason: full-stack, mobile, infrastructure, and backend app builds often fail
+  because the local workspace is not provisioned, even when the code task is
+  otherwise clear.
 
 - Decision: start separating shared OpenReactor runtime code from repo-local
   product steering state by introducing a committed `.openreactor/repo/`

--- a/OPENREACTOR_WORKFLOW.md
+++ b/OPENREACTOR_WORKFLOW.md
@@ -66,7 +66,9 @@ maintainer consideration.
 - If the selected implementation provider is unavailable, OpenReactor should
   retry the run through the other provider before giving up on the issue. Only
   when both providers appear unavailable should it pause the issue and wait for
-  provider recovery.
+  provider recovery. UI-specialized work is the exception: OpenReactor should
+  use the Codex UI path for frontend work rather than falling back to a
+  non-image-capable Claude UI path.
 - When OpenReactor asks GitHub for auto-merge on an accepted PR, it should
   fall back to a direct merge only when the target repo does not support
   native GitHub auto-merge at all. Clean accepted PRs should not be left open
@@ -93,6 +95,15 @@ maintainer consideration.
   not only markdown links to them. If another implementation path cannot
   accept deterministic image attachments yet, OpenReactor should route that
   issue through a path that can.
+- Frontend/design-heavy issues should route to `spawn_codex_ui_agent`. That
+  path should run a Codex UI design prepass with `xhigh` reasoning, create a
+  concrete design image and brief in the run directory, then attach that image
+  to the implementation Codex run along with any issue-provided reference
+  images.
+- OpenReactor should use stack-specific workflows for known high-variance work:
+  frontend/UI, backend/API, database/data model, infrastructure/deployment,
+  mobile, AI/agent behavior, data ingestion, security/auth/payments, and
+  broad full-stack app builds.
 - OpenReactor should refresh PR execution footers after the run finishes so
   the final PR body deterministically reflects the implementation agent that
   actually produced the result.
@@ -132,6 +143,27 @@ OpenReactor should separate:
 - shared engine/runtime code
 - repo-local product steering state
 
+### Project Genesis
+
+New products should usually go through a Project Genesis pass before
+OpenReactor starts autonomous implementation.
+
+Genesis is a real-time product-design collaboration between the product owner
+and a ChatGPT/Codex agent. It is where the agent asks clarifying questions,
+pushes back on weak assumptions, defines the v0 product nucleus, and writes
+OpenReactor-ready repo state.
+
+OpenReactor should consume the Genesis output after it has been reviewed and
+committed. The reactor should not be stretched into a live planning interface;
+its job is backend execution against durable repo-local product state and
+GitHub issues.
+
+The canonical Genesis output contract lives in
+[`GENESIS_WORKFLOW.md`](GENESIS_WORKFLOW.md).
+
+The canonical stack-specific execution guidance lives in
+[`STACK_WORKFLOWS.md`](STACK_WORKFLOWS.md).
+
 The repo-local state is where product-specific direction, roadmap, and durable
 memory should live for a managed repository. The current committed layout is:
 
@@ -159,7 +191,8 @@ OpenReactor engine repo. Repo-local constitutions should carry product-specific
 rules, but shared workflow logic should not be stranded in one private managed
 repo.
 
-For managed repos, initialization should prefer inference over blank setup:
+For managed repos that did not go through Project Genesis, initialization
+should still prefer inference over blank setup:
 
 - read the repo README
 - read the initial GitHub issues, especially a PRD-style issue if one exists
@@ -187,6 +220,15 @@ The current local deployment model is intentionally simple:
 Legacy repos that already have the older top-level product docs may continue to
 run while the bootstrap PR is open. Repos that do not have either repo-local
 state or the legacy top-level docs should wait for the bootstrap first.
+
+Before starting a brand-new product from Genesis output, operators should run:
+
+```bash
+bun run reactor:tool check-genesis
+```
+
+That check verifies that required `.openreactor/repo/` steering files exist and
+do not still look like untouched bootstrap placeholders.
 
 This avoids a separate onboarding wizard while still keeping the runtime local
 and the per-repo steering state committed inside the managed repository.

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -37,8 +37,9 @@ This document is binding for all agents unless superseded by explicit maintainer
 
 ### 3.3 Scope filter
 A request should be rejected/deferred if:
-- effort is too large for one iteration,
-- it requires unavailable infrastructure/secrets,
+- effort is too large for one iteration and cannot be usefully decomposed,
+- it requires unavailable infrastructure/secrets with no safe implementation
+  slice or human handoff path,
 - it significantly diverges from current product direction.
 
 ## 4) User Experience (MVP)
@@ -58,6 +59,24 @@ A request should be rejected/deferred if:
 10. Clean accepted PRs may be merged automatically by the reactor or watchdog, depending on repository capabilities and current runtime state.
 11. On merge to `main`, the website deploys automatically.
 
+## 4.1) Project Genesis
+
+For a brand-new product, the initial product-design phase is intentionally
+outside the OpenReactor runtime.
+
+Project Genesis should be a real-time collaboration between the product owner
+and a ChatGPT/Codex agent. That agent turns the initial product prompt into
+OpenReactor-ready repo-local state, including product spec, constitution,
+triage policy, roadmap, memory, optional workspace policy, and a small initial
+issue backlog.
+
+OpenReactor then consumes the committed Genesis output as backend execution
+state. The reactor should not be treated as the interactive planning surface
+for new-product discovery.
+
+The shipped contract for this workflow is documented in
+`GENESIS_WORKFLOW.md`.
+
 ## 5) System Architecture (MVP)
 - Frontend: public website for request intake and queue visibility
 - Website backend: API/backend for intake and future product features that require stored data
@@ -68,6 +87,8 @@ A request should be rejected/deferred if:
   through a real run
 - OpenReactor status service: machine-local read-only metadata endpoint that exposes intake, triage/planning, execution, retry, blocked, and completed pipeline metadata to the website without giving the website direct control over the local runtime
 - OpenReactor status contract: a graph-oriented automation-status payload that is intended to generalize beyond OpenReactor-specific pipeline layouts, with OpenReactor details carried in namespaced extensions
+- Project Genesis contract: documented external ChatGPT/Codex planning workflow that produces OpenReactor-ready repo-local product state before the reactor begins implementation on a new product
+- Stack workflow contract: documented stack-specific execution patterns for frontend, backend/API, database, infrastructure, mobile, AI/agent, data ingestion, security/auth/payments, and full-stack builds
 - GitHub integration: issues, labels, comments, branches, PRs, merge state
 - Persistence (current): GitHub for durable workflow state, local `.openreactor/` files for transient run state such as run records, event logs, transcripts, live snapshots, watchdog state, archives, and repo-local steering/workspace-policy files
 - Persistence (planned): application database for website/backend features that require stored data
@@ -79,6 +100,9 @@ Current agent-workflow state lives in:
 - GitHub pull requests
 - local `.openreactor/runs/*` state files
 - repo-local `workspace-policy.json` or `.openreactor/repo/workspace-policy.json` execution policy files
+- generated UI design prepass artifacts for Codex UI runs:
+  `ui-design-reference.svg` and `ui-design-brief.md` in the issue run
+  directory
 
 Planned backend data model for product features that require stored data:
 - feature_requests
@@ -125,6 +149,12 @@ Agent behavior requirements:
 - enforce minimum acceptance evidence for shipped work, including a real branch,
   a real PR, and at least one passing reported check
 - require browser-verification evidence before accepting UI work
+- route frontend/design-heavy issues to the Codex UI agent, which first runs a
+  Codex `xhigh` design-image prepass and then feeds the generated image into
+  the implementation run with any issue-provided reference images
+- use stack-specific workflow guidance from `STACK_WORKFLOWS.md` when a request
+  touches backend/API, data model, infrastructure, mobile, AI/agent, data
+  ingestion, security/auth/payments, or broad full-stack app work
 
 ## 7.1) Canonical GitHub Support Signal
 
@@ -170,6 +200,9 @@ Split the product backend from the agent runtime:
 - GitHub polling is the current trigger mechanism; webhooks are optional later
 - GitHub + local run files are sufficient for the first autonomous loop
 - richer backend storage remains planned when the product itself needs it
+- workspace policy provision commands now run during managed-repo issue startup
+  before the implementation agent starts, with non-secret policy environment
+  values forwarded into agent processes
 
 ## 9) Deployment and CD
 - Main branch deploys automatically.
@@ -282,8 +315,11 @@ What is already live:
     surface with recent activity and transcript previews,
 19. a shared status contract package used by the local status service and the
     website bridge,
-20. and an OpenReactor Autonomous Test Run command for deliberate end-to-end
-    canary verification.
+20. an OpenReactor Autonomous Test Run command for deliberate end-to-end
+    canary verification,
+21. and a documented Project Genesis output contract for preparing
+    OpenReactor-ready repo-local state through an external ChatGPT/Codex
+    planning conversation.
 
 The following are still deferred:
 
@@ -292,5 +328,6 @@ The following are still deferred:
 - accepted/rejected aggregate metrics in the public site,
 - PR cycle-time reporting in the public site,
 - latest product-memory reporting in the public site,
+- first-class Genesis automation or a hosted interactive Genesis UI,
 - application-backed stored data features for the website/backend,
 - and richer product features that genuinely require a separate durable backend.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,25 @@ OpenReactor is moving toward a split between:
 - the shared OpenReactor engine, which stays centralized
 - the repo-local product steering state, which travels with the target repo
 
+### Project Genesis
+
+New products should usually begin with a **Project Genesis** pass before
+OpenReactor starts implementation work.
+
+Genesis is an interactive product-design workflow run with a ChatGPT/Codex
+agent in direct collaboration with the product owner. That agent asks
+questions, challenges weak assumptions, narrows the first build, and writes the
+repo-local product state that OpenReactor needs.
+
+OpenReactor should then consume the committed Genesis output as backend
+execution state. It should not be treated as the real-time interview interface
+for the planning phase.
+
+The canonical output contract lives in
+[GENESIS_WORKFLOW.md](GENESIS_WORKFLOW.md). Stack-specific execution guidance
+for frontend, backend, mobile, infrastructure, AI, data, auth, and full-stack
+work lives in [STACK_WORKFLOWS.md](STACK_WORKFLOWS.md).
+
 The first committed shape for that repo-local state is:
 
 - `.openreactor/repo/README.md`
@@ -175,6 +194,12 @@ Bootstrap that repo-local steering layer manually with:
 bun run reactor:tool init-repo-state
 ```
 
+Check whether a Genesis output is ready for implementation with:
+
+```bash
+bun run reactor:tool check-genesis
+```
+
 That bootstrap now tries to seed the repo-local files from:
 
 - the repo README, if one exists
@@ -182,16 +207,20 @@ That bootstrap now tries to seed the repo-local files from:
 
 The intended managed-repo flow is:
 
-1. user creates a repo and writes an initial PRD, usually as a README or an
-   initial GitHub issue,
-2. user installs the OpenReactor GitHub App on that repo,
-3. the local OpenReactor runtime starts against a clone of that repo,
-4. OpenReactor infers a first-pass product description from the repo README and
-   the existing GitHub issue discussion,
-5. OpenReactor automatically opens a bootstrap PR creating `.openreactor/repo/`
-   from that material,
+1. user collaborates with a ChatGPT/Codex Genesis agent on the initial product
+   direction,
+2. the Genesis agent writes OpenReactor-ready repo-local state under
+   `.openreactor/repo/` and, when useful, a small initial issue backlog,
+3. user reviews and commits or merges that Genesis output,
+4. user installs the OpenReactor GitHub App on that repo,
+5. the local OpenReactor runtime starts against a clone of that repo,
 6. once that repo-local state exists on `main`, OpenReactor proceeds with the
    normal issue loop.
+
+The fallback bootstrap flow still exists for repos that did not go through
+Genesis. In that case, OpenReactor can infer a first-pass repo state from the
+README and existing GitHub issues, then open a bootstrap PR for maintainer
+review.
 
 For older repos that already have the legacy top-level product docs
 (`README.md`, `PRODUCT_SPEC.md`, `PRODUCT_CONSTITUTION.md`, `ROADMAP.md`,
@@ -396,9 +425,15 @@ Useful environment variables:
 - `OPENREACTOR_AGENT_MODEL`
 - `OPENREACTOR_AGENT_REASONING_EFFORT`
 - `OPENREACTOR_AGENT_SERVICE_TIER`
-- `OPENREACTOR_CLAUDE_UI_MODEL`
-- `OPENREACTOR_CLAUDE_UI_EFFORT`
-- `OPENREACTOR_CLAUDE_UI_BIN`
+- `OPENREACTOR_CODEX_UI_MODEL`
+- `OPENREACTOR_CODEX_UI_REASONING_EFFORT`
+- `OPENREACTOR_CODEX_UI_SERVICE_TIER`
+- `OPENREACTOR_UI_DESIGN_MODEL`
+- `OPENREACTOR_UI_DESIGN_REASONING_EFFORT`
+- `OPENREACTOR_UI_DESIGN_SERVICE_TIER`
+- `OPENREACTOR_CLAUDE_MODEL`
+- `OPENREACTOR_CLAUDE_EFFORT`
+- `OPENREACTOR_CLAUDE_BIN`
 - `OPENREACTOR_STATUS_BIND_HOST`
 - `OPENREACTOR_STATUS_PORT`
 - `OPENREACTOR_STATUS_TOKEN`
@@ -415,6 +450,7 @@ Helper tooling for issue agents:
 
 ```bash
 bun run reactor:tool --help
+bun run reactor:tool check-genesis
 bun run reactor:tool coauthor-trailer --username octocat
 bun run agent-browser:install
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,21 +2,28 @@
 
 ## Now
 
-Launch the thinnest loop that allows OpenReactor to begin collecting work and start processing issues autonomously:
+Stabilize OpenReactor as a backend execution loop for products whose product
+state has already been made explicit:
 
-1. Public website with request form
-2. Request validation and normalization
-3. GitHub issue creation
-4. Public queue view of recent requests
-5. Local `reactor/` loop that claims issues and spawns agents
+1. Keep the autonomous issue-to-PR loop reliable.
+2. Treat Project Genesis as an external ChatGPT/Codex workflow that produces
+   OpenReactor-ready repo-local state.
+3. Keep `.openreactor/repo/` docs curated enough that agents inherit concrete
+   product truth instead of placeholders.
+4. Use stack-specific workflows so frontend, backend, mobile, infrastructure,
+   AI, data, security, and full-stack app work get sharper instructions than a
+   generic coding-agent pass.
+5. Preserve observability through the public queue, status feed, and runtime
+   artifacts.
 
 ## Next
 
-Once the intake loop and first reactor loop are stable:
+Improve readiness for new full-product builds:
 
-1. Make accepted issues reliably create branches, commits, and PRs
-2. Add PR follow-up and merge-state handling
-3. Tighten prompts, plans, and quality gates based on live runs
+1. Add deployment health tracking and incident issue creation.
+2. Tighten prompts, plans, and quality gates based on live managed-repo runs.
+3. Add richer stack profiles when live failures show repeated gaps.
+4. Add targeted evals for Genesis output quality and UI design-prepass quality.
 
 ## Later
 
@@ -24,4 +31,7 @@ Only after repeated live usage validates the workflow:
 
 1. Add application-backed stored data features for the website/backend
 2. Add persistent internal state beyond GitHub where it is actually needed
-3. Add deployment status tracking and transparency metrics
+3. Add first-class Genesis automation or hosted Genesis UI only if the external
+   Codex workflow proves insufficient
+4. Expand multi-repo and infrastructure orchestration once the local model is
+   reliable

--- a/STACK_WORKFLOWS.md
+++ b/STACK_WORKFLOWS.md
@@ -1,0 +1,138 @@
+# OpenReactor Stack Workflows
+
+OpenReactor should not use one generic implementation path for every kind of
+software work. Different parts of the stack fail in different ways, so agents
+should inherit stack-specific workflow rules when a request touches those
+surfaces.
+
+## Frontend And UI
+
+Use `spawn_codex_ui_agent` for visual or interaction-heavy work.
+
+Workflow:
+
+1. Run a Codex UI design prepass with `xhigh` reasoning.
+2. Produce a concrete design image and a short design brief in the run
+   directory.
+3. Feed that generated image, plus any issue-provided reference images, into
+   the Codex UI implementation run.
+4. Implement against the existing UI system and product constraints.
+5. Verify in browser at desktop and narrow/mobile widths before accepting.
+
+The generated design image is not decorative inspiration. It is an
+implementation artifact for layout, hierarchy, component density, responsive
+behavior, and interaction states. If an issue-provided reference image conflicts
+with the generated design image, the issue-provided reference image wins.
+
+## Backend And APIs
+
+Backend work should start from a contract:
+
+- define request/response shapes or function contracts before implementation
+- add or update tests around observable behavior
+- keep validation, auth, and error cases explicit
+- avoid speculative service boundaries
+- document any current limitation that remains after the slice ships
+
+For public APIs, include compatibility and failure-mode notes in the PR body.
+For internal APIs, prioritize maintainability and tests over premature generic
+abstractions.
+
+## Database And Data Model
+
+Data work should be migration-first:
+
+- state the data invariants before changing schema or persistence
+- add seed or fixture coverage where possible
+- keep migrations idempotent when the platform supports it
+- avoid pretending production data was migrated when a human-only step remains
+- document rollback or cleanup expectations for maintainer review
+
+If the repo lacks a real database yet, the agent should not invent one unless
+the accepted product slice truly needs persistence.
+
+## Infrastructure And Deployment
+
+Infrastructure work should separate planning from applying:
+
+- prepare configuration, scripts, and docs in a PR
+- use `workspace-policy.json` for local provision and teardown hooks
+- never commit secrets or account-specific credentials
+- treat cloud account setup, DNS, paid services, app signing, and production
+  deploy permissions as human handoffs unless the repo explicitly provides safe
+  automation
+- run read-only or local validation where possible before handoff
+
+Agents may prepare infrastructure changes, but they should not claim production
+infrastructure is live without evidence from the target environment.
+
+## Mobile Apps
+
+Mobile work needs platform-specific verification:
+
+- identify iOS, Android, or cross-platform targets in the issue plan
+- prefer emulator/simulator or platform test commands when available
+- verify layout across at least one small and one normal device size for UI work
+- treat signing, app-store credentials, push notification keys, and device
+  provisioning as human handoffs
+- document platform-specific assumptions in the PR body
+
+If no mobile toolchain is configured, the agent should still prepare the code
+slice and hand off the missing setup explicitly.
+
+## AI And Agent Features
+
+AI-facing work should be eval-aware:
+
+- prefer structured outputs for machine-read results
+- keep stable prompt and tool instructions in durable files
+- add small fixtures, eval cases, or transcript-based checks when behavior is
+  hard to unit test
+- record model, reasoning effort, and tool assumptions
+- keep secrets and private prompts out of logs and examples
+
+For OpenAI/Codex-specific work, use current official OpenAI docs when choosing
+models, reasoning effort, hosted tools, structured output patterns, or Codex
+configuration.
+
+## Data Ingestion And Scraping
+
+Data ingestion work should be rights-aware and repeatable:
+
+- verify that the source can be used legally and safely
+- respect rate limits, robots guidance, and terms where applicable
+- use fixtures for tests instead of depending on live remote content
+- make ingestion idempotent and resumable
+- log counts and failures without leaking private data
+
+Requests to publish or transform large copyrighted third-party content without
+clear rights should be rejected, not refined into implementation.
+
+## Security, Auth, And Payments
+
+Security-sensitive work requires explicit threat and handoff notes:
+
+- identify trust boundaries, roles, and privileged actions
+- test denied paths as well as happy paths
+- use test-mode payments and sandbox credentials only
+- never commit secrets, tokens, customer data, or private keys
+- require maintainer handoff for production OAuth apps, payment accounts,
+  production secrets, and policy decisions
+
+Do not accept security, auth, or payment work as complete if the remaining
+production step is outside the agent's access.
+
+## Cross-Stack Full-Stack Apps
+
+For full-stack app builds, the planner should decompose by risk boundary:
+
+- product nucleus and acceptance criteria from Genesis
+- UI shell and core workflow
+- backend/API contract
+- data model and persistence
+- auth/security if needed
+- infrastructure/deployment
+- verification and handoff
+
+Independent slices should be parallelizable. True dependencies should be
+captured as GitHub issue dependencies instead of implied through issue text.

--- a/UI_SYSTEM.md
+++ b/UI_SYSTEM.md
@@ -73,3 +73,12 @@ Preferred tooling:
 - Playwright if the issue already uses it or the repo adds targeted tests
 
 Static code inspection alone is not enough for UI acceptance.
+
+## Codex UI workflow
+
+OpenReactor should route UI-heavy issues through the Codex UI agent.
+
+That workflow creates a generated design reference image and design brief before
+implementation. The implementation agent should use those artifacts as concrete
+direction for layout, hierarchy, component density, and responsive behavior
+while still preserving the existing UI system and browser-verifying the result.

--- a/ops/reactor.env.example
+++ b/ops/reactor.env.example
@@ -42,9 +42,17 @@ GITHUB_APP_PRIVATE_KEY=
 # OPENREACTOR_AGENT_REASONING_EFFORT=medium
 # Optional. Leave unset unless you have a known-good service tier for this Codex build/account.
 # OPENREACTOR_AGENT_SERVICE_TIER=
-# OPENREACTOR_CLAUDE_UI_MODEL=sonnet
-# OPENREACTOR_CLAUDE_UI_EFFORT=medium
-# OPENREACTOR_CLAUDE_UI_BIN=/home/ray/.local/bin/claude
+# OPENREACTOR_CODEX_UI_MODEL=gpt-5.5
+# OPENREACTOR_CODEX_UI_REASONING_EFFORT=high
+# Optional. Leave unset unless you have a known-good service tier for this Codex build/account.
+# OPENREACTOR_CODEX_UI_SERVICE_TIER=
+# OPENREACTOR_UI_DESIGN_MODEL=gpt-5.5
+# OPENREACTOR_UI_DESIGN_REASONING_EFFORT=xhigh
+# Optional. Leave unset unless you have a known-good service tier for this Codex build/account.
+# OPENREACTOR_UI_DESIGN_SERVICE_TIER=
+# OPENREACTOR_CLAUDE_MODEL=sonnet
+# OPENREACTOR_CLAUDE_EFFORT=medium
+# OPENREACTOR_CLAUDE_BIN=/home/ray/.local/bin/claude
 # OPENREACTOR_BOT_MENTION_ALIASES=@openreactor,@openreactor[bot],@open-reactor-bot,@open-reactor-bot[bot]
 
 # Optional watchdog tuning.

--- a/packages/factory-floor/demo/mock-data.json
+++ b/packages/factory-floor/demo/mock-data.json
@@ -136,7 +136,7 @@
         "assignedActorId": "openreactor:actor:290",
         "enteredStateAt": "2026-03-26T09:15:00.000Z",
         "retryCount": 1,
-        "extensions": { "openreactor": { "issueNumber": 290, "issueUrl": "https://github.com/rayzhudev/openreactor/issues/290", "branchName": "openreactor/issue-290", "toolLabel": "Claude UI agent" } }
+        "extensions": { "openreactor": { "issueNumber": 290, "issueUrl": "https://github.com/rayzhudev/openreactor/issues/290", "branchName": "openreactor/issue-290", "toolLabel": "Codex UI agent" } }
       },
       {
         "id": "openreactor:issue:280",
@@ -216,16 +216,16 @@
       {
         "id": "openreactor:actor:290",
         "kind": "agent",
-        "label": "Claude UI Agent",
+        "label": "Codex UI Agent",
         "role": "ui",
         "status": "working",
         "currentNodeId": "execution",
         "currentItemId": "openreactor:issue:290",
-        "provider": "claude",
-        "model": "claude-sonnet-4-6",
+        "provider": "codex",
+        "model": "gpt-5.5",
         "startedAt": "2026-03-26T09:15:00.000Z",
         "lastHeartbeatAt": "2026-03-26T09:58:00.000Z",
-        "extensions": { "openreactor": { "issueNumber": 290, "toolName": "spawn_claude_ui_agent", "toolLabel": "Claude UI agent", "iteration": 2 } }
+        "extensions": { "openreactor": { "issueNumber": 290, "toolName": "spawn_codex_ui_agent", "toolLabel": "Codex UI agent", "iteration": 2 } }
       }
     ],
     "executions": [
@@ -309,7 +309,7 @@
         "level": "info",
         "subjectType": "item",
         "subjectId": "openreactor:issue:290",
-        "message": "Claude UI agent polishing playground story navigation (attempt 2)."
+        "message": "Codex UI agent polishing playground story navigation (attempt 2)."
       },
       {
         "id": "evt-3",

--- a/packages/factory-floor/demo/simulation.ts
+++ b/packages/factory-floor/demo/simulation.ts
@@ -44,7 +44,7 @@ const ISSUE_TITLES = [
 
 const AGENT_TEMPLATES = [
   { role: "general", label: "Codex Agent", provider: "codex", model: "gpt-5.3-codex-spark" },
-  { role: "ui", label: "Claude UI Agent", provider: "claude", model: "claude-sonnet-4-6" },
+  { role: "ui", label: "Codex UI Agent", provider: "codex", model: "gpt-5.5" },
   { role: "planning", label: "Codex Planner", provider: "codex", model: "gpt-5.3-codex-spark" },
 ];
 

--- a/prompts/issue-agent.md
+++ b/prompts/issue-agent.md
@@ -8,21 +8,16 @@ You are the autonomous agent for one GitHub issue.
 2. Read the OpenReactor engine's `quality-gates.md` prompt file provided in your run instructions.
 3. Read the OpenReactor engine's `CONSTITUTION.md`.
 4. Read the repo-local product spec, roadmap, memory, and README under `.openreactor/repo/` when present, otherwise read `PRODUCT_SPEC.md`, `ROADMAP.md`, `MEMORY.md`, and `README.md`.
-5. Read the repo-local product constitution under `.openreactor/repo/` when present, otherwise `PRODUCT_CONSTITUTION.md`, and read `OPENREACTOR_WORKFLOW.md`.
-6. If you touch UI, read the repo-local UI system file when present, otherwise `UI_SYSTEM.md`, before editing.
-7. Read the issue context file provided in the run directory.
-8. If the issue context lists reference images, inspect them before making implementation decisions.
-9. Read `progress.md` if it already exists.
-10. If `plan.json` exists, use it. If not, create it before coding.
-11. Prefer the OpenReactor helper command exposed at `$OPENREACTOR_ENGINE_TOOL` when it makes the workflow more reliable.
-5. Read the repo-local triage policy under `.openreactor/repo/` when present, otherwise `TRIAGE_POLICY.md` if it exists.
-6. Read `OPENREACTOR_WORKFLOW.md`.
-7. If you touch UI, read the repo-local UI system file when present, otherwise `UI_SYSTEM.md`, before editing.
-8. Read the issue context file provided in the run directory.
-9. If the issue context lists reference images, inspect them before making implementation decisions.
-10. Read `progress.md` if it already exists.
-11. If `plan.json` exists, use it. If not, create it before coding.
-12. Prefer the OpenReactor helper command exposed at `$OPENREACTOR_ENGINE_TOOL` when it makes the workflow more reliable.
+5. Read the repo-local product constitution under `.openreactor/repo/` when present, otherwise `PRODUCT_CONSTITUTION.md`.
+6. Read the repo-local triage policy under `.openreactor/repo/` when present, otherwise `TRIAGE_POLICY.md` if it exists.
+7. Read `OPENREACTOR_WORKFLOW.md`.
+8. Read `STACK_WORKFLOWS.md` when the issue touches frontend, backend/API, database, infrastructure, mobile, AI/agent behavior, data ingestion, security/auth/payments, or full-stack app work.
+9. If you touch UI, read the repo-local UI system file when present, otherwise `UI_SYSTEM.md`, before editing.
+10. Read the issue context file provided in the run directory.
+11. If the issue context lists reference images, inspect them before making implementation decisions.
+12. Read `progress.md` if it already exists.
+13. If `plan.json` exists, use it. If not, create it before coding.
+14. Prefer the OpenReactor helper command exposed at `$OPENREACTOR_ENGINE_TOOL` when it makes the workflow more reliable.
 
 ## Your Authority
 
@@ -104,6 +99,8 @@ Use the right file for the right kind of knowledge:
 - `MEMORY.md`: durable decisions, lessons, and constraints
 - `README.md`: public-facing usage, setup, and operator guidance
 - `UI_SYSTEM.md`: standing UI rules, not one-off implementation notes
+- `GENESIS_WORKFLOW.md`: output contract for external ChatGPT/Codex new-product planning
+- `STACK_WORKFLOWS.md`: stack-specific workflow rules for frontend, backend/API, database, infrastructure, mobile, AI/agent, data ingestion, security/auth/payments, and full-stack work
 - `prompts/`: standing issue-loop behavior that future autonomous runs should follow
 
 Before you finish a non-trivial run, do a docs audit:
@@ -113,6 +110,8 @@ Before you finish a non-trivial run, do a docs audit:
 - If you learned something durable, update `MEMORY.md`.
 - If public-facing usage or setup changed, update `README.md`.
 - If standing UI rules changed, update `UI_SYSTEM.md`.
+- If the external new-product planning contract changed, update `GENESIS_WORKFLOW.md`.
+- If stack-specific agent workflow changed, update `STACK_WORKFLOWS.md`.
 - If standing autonomous behavior changed, update the relevant file in `prompts/`.
 
 Do not leave those decisions implicit. Record shared-doc updates, or the reason

--- a/prompts/product-context.md
+++ b/prompts/product-context.md
@@ -32,6 +32,17 @@ Core rules:
 - Use the repo-local product docs to decide which surfaces are most
   identity-shaping and which classes of work are strategically core for that
   product.
+- For brand-new products, treat Project Genesis as an external ChatGPT/Codex
+  collaboration that produces OpenReactor-ready repo-local state. Do not try
+  to turn the reactor itself into the live planning interface unless a
+  maintainer explicitly asks to change that boundary.
+- For frontend/design-heavy issues, expect the Codex UI path: generate a UI
+  design reference image and brief first, then feed that image into the
+  implementation agent with any issue-provided reference images.
+- For specialized stack work, use `STACK_WORKFLOWS.md` rather than applying one
+  generic implementation pattern to frontend, backend/API, database,
+  infrastructure, mobile, AI/agent, data ingestion, security/auth/payments, or
+  full-stack app work.
 - Privileged internal or admin behavior is a hard boundary: unless the issue is
   maintainer-steered, public feedback should not directly change it.
 - Final user-facing issue states are only `accepted` or `rejected`.
@@ -46,6 +57,7 @@ Always read and follow these local documents before deciding:
 - `.openreactor/repo/PRODUCT_CONSTITUTION.md` when present, otherwise `PRODUCT_CONSTITUTION.md`
 - `.openreactor/repo/TRIAGE_POLICY.md` when present, otherwise `TRIAGE_POLICY.md` if it exists
 - `OPENREACTOR_WORKFLOW.md`
+- `STACK_WORKFLOWS.md` when the request touches a specialized stack area
 - `.openreactor/repo/ROADMAP.md` when present, otherwise `ROADMAP.md`
 - `.openreactor/repo/MEMORY.md` when present, otherwise `MEMORY.md`
 - `.openreactor/repo/README.md` when present, otherwise `README.md`
@@ -87,6 +99,10 @@ Shared-memory update rules:
   surface-routing rule changes for this product.
 - Update `OPENREACTOR_WORKFLOW.md` when a durable OpenReactor process or
   workflow changes.
+- Update `GENESIS_WORKFLOW.md` when the contract for external new-product
+  planning output changes.
+- Update `STACK_WORKFLOWS.md` when durable stack-specific execution guidance
+  changes.
 - Update `CONSTITUTION.md` when the boundary between OpenReactor and product
   changes.
 - Update files in `prompts/` when future issue agents need different standing instructions.

--- a/prompts/triage-agent.md
+++ b/prompts/triage-agent.md
@@ -71,9 +71,10 @@ Rules:
 - Also choose `spawn_codex_planner_agent` when one feedback post contains a mix
   of independently valid and invalid asks, so the valid subset can be preserved
   as child issues instead of forcing an all-or-nothing judgment on the parent.
-- Choose `spawn_claude_ui_agent` for issues that are primarily about frontend
+- Choose `spawn_codex_ui_agent` for issues that are primarily about frontend
   design, layout, styling, UI polish, component presentation, or other visual
-  UX work.
+  UX work. This path creates a Codex-generated design image first and feeds it
+  into the frontend implementation run.
 - Choose `spawn_codex_issue_agent` for everything else, including backend,
   orchestration, infrastructure, APIs, and mixed full-stack work.
 - Treat admin or privileged internal changes as high sensitivity. Unless the

--- a/prompts/ui-agent.md
+++ b/prompts/ui-agent.md
@@ -5,6 +5,12 @@ Use this prompt as the frontend design skill equivalent for UI-heavy issues.
 Rules:
 
 - Read `UI_SYSTEM.md` before making visual decisions.
+- If the run instructions mention a generated UI design reference image and
+  design brief, inspect both before editing UI code. Treat them as the primary
+  implementation artifact for layout, hierarchy, density, and interaction
+  states, subject to existing product constraints and accessibility.
+- If issue-provided reference images conflict with the generated design image,
+  prioritize the issue-provided reference images.
 - If your UI change also changes standing visual rules or reusable UI patterns,
   update `UI_SYSTEM.md` in the same run instead of leaving the new rule only in
   code.

--- a/reactor/agent-tools.ts
+++ b/reactor/agent-tools.ts
@@ -1,9 +1,9 @@
 export type AgentToolName =
   | "spawn_codex_issue_agent"
+  | "spawn_codex_ui_agent"
   | "spawn_codex_planner_agent"
   | "spawn_claude_issue_agent"
-  | "spawn_claude_planner_agent"
-  | "spawn_claude_ui_agent";
+  | "spawn_claude_planner_agent";
 
 export interface AgentToolDefinition {
   name: AgentToolName;
@@ -35,6 +35,15 @@ export const AGENT_TOOLS: Record<AgentToolName, AgentToolDefinition> = {
     primaryUse: "planning",
     triageSelectable: true
   },
+  spawn_codex_ui_agent: {
+    name: "spawn_codex_ui_agent",
+    label: "Codex UI Agent",
+    description:
+      "Frontend-focused Codex agent for visual design, layout, styling, interaction polish, and UI-heavy product work. Runs a high-reasoning design-image prepass before implementation.",
+    provider: "codex",
+    primaryUse: "ui",
+    triageSelectable: true
+  },
   spawn_claude_issue_agent: {
     name: "spawn_claude_issue_agent",
     label: "Claude Issue Agent",
@@ -52,25 +61,16 @@ export const AGENT_TOOLS: Record<AgentToolName, AgentToolDefinition> = {
     provider: "claude",
     primaryUse: "planning",
     triageSelectable: false
-  },
-  spawn_claude_ui_agent: {
-    name: "spawn_claude_ui_agent",
-    label: "Claude UI Agent",
-    description:
-      "Frontend-focused implementation agent for visual design, layout, styling, interaction polish, and other UI-heavy work.",
-    provider: "claude",
-    primaryUse: "ui",
-    triageSelectable: true
   }
 };
 
 export function isAgentToolName(value: string | null | undefined): value is AgentToolName {
   return (
     value === "spawn_codex_issue_agent" ||
+    value === "spawn_codex_ui_agent" ||
     value === "spawn_codex_planner_agent" ||
     value === "spawn_claude_issue_agent" ||
-    value === "spawn_claude_planner_agent" ||
-    value === "spawn_claude_ui_agent"
+    value === "spawn_claude_planner_agent"
   );
 }
 
@@ -97,12 +97,12 @@ export function getFallbackToolForProviderOutage(
       return "spawn_claude_issue_agent";
     case "spawn_codex_planner_agent":
       return "spawn_claude_planner_agent";
+    case "spawn_codex_ui_agent":
+      return null;
     case "spawn_claude_issue_agent":
       return "spawn_codex_issue_agent";
     case "spawn_claude_planner_agent":
       return "spawn_codex_planner_agent";
-    case "spawn_claude_ui_agent":
-      return "spawn_codex_issue_agent";
     default:
       return null;
   }

--- a/reactor/config.ts
+++ b/reactor/config.ts
@@ -42,9 +42,15 @@ export interface OrchestratorConfig {
   agentModel: string;
   agentReasoningEffort: string;
   agentServiceTier: string;
-  claudeUiModel: string;
-  claudeUiEffort: string;
-  claudeUiBin: string;
+  codexUiModel: string;
+  codexUiReasoningEffort: string;
+  codexUiServiceTier: string;
+  uiDesignModel: string;
+  uiDesignReasoningEffort: string;
+  uiDesignServiceTier: string;
+  claudeModel: string;
+  claudeEffort: string;
+  claudeBin: string;
   botMentionAliases: string[];
 }
 
@@ -104,9 +110,31 @@ export function loadConfig(repoRoot = resolveManagedRepoRoot()): OrchestratorCon
     agentReasoningEffort:
       clean(process.env.OPENREACTOR_AGENT_REASONING_EFFORT) || "medium",
     agentServiceTier: clean(process.env.OPENREACTOR_AGENT_SERVICE_TIER),
-    claudeUiModel: clean(process.env.OPENREACTOR_CLAUDE_UI_MODEL) || "sonnet",
-    claudeUiEffort: clean(process.env.OPENREACTOR_CLAUDE_UI_EFFORT) || "medium",
-    claudeUiBin: clean(process.env.OPENREACTOR_CLAUDE_UI_BIN) || "claude",
+    codexUiModel:
+      clean(process.env.OPENREACTOR_CODEX_UI_MODEL) ||
+      clean(process.env.OPENREACTOR_AGENT_MODEL) ||
+      "gpt-5.5",
+    codexUiReasoningEffort:
+      clean(process.env.OPENREACTOR_CODEX_UI_REASONING_EFFORT) || "high",
+    codexUiServiceTier:
+      clean(process.env.OPENREACTOR_CODEX_UI_SERVICE_TIER) ||
+      clean(process.env.OPENREACTOR_AGENT_SERVICE_TIER),
+    uiDesignModel:
+      clean(process.env.OPENREACTOR_UI_DESIGN_MODEL) ||
+      clean(process.env.OPENREACTOR_CODEX_UI_MODEL) ||
+      clean(process.env.OPENREACTOR_AGENT_MODEL) ||
+      "gpt-5.5",
+    uiDesignReasoningEffort:
+      clean(process.env.OPENREACTOR_UI_DESIGN_REASONING_EFFORT) || "xhigh",
+    uiDesignServiceTier:
+      clean(process.env.OPENREACTOR_UI_DESIGN_SERVICE_TIER) ||
+      clean(process.env.OPENREACTOR_CODEX_UI_SERVICE_TIER) ||
+      clean(process.env.OPENREACTOR_AGENT_SERVICE_TIER),
+    claudeModel:
+      clean(process.env.OPENREACTOR_CLAUDE_MODEL) ||
+      "sonnet",
+    claudeEffort: clean(process.env.OPENREACTOR_CLAUDE_EFFORT) || "medium",
+    claudeBin: clean(process.env.OPENREACTOR_CLAUDE_BIN) || "claude",
     botMentionAliases: listFromEnv(
       "OPENREACTOR_BOT_MENTION_ALIASES",
       [

--- a/reactor/index.ts
+++ b/reactor/index.ts
@@ -55,6 +55,7 @@ import {
   REPO_STATE_DIR,
   type RepoStateSeedIssue
 } from "./repo-state";
+import { runWorkspacePolicyCommand } from "./workspace-policy";
 
 const execFileAsync = promisify(execFile);
 
@@ -536,7 +537,7 @@ class Reactor {
       const tool = getAgentTool(toolName);
       await this.syncIssueStatusComment(issue.number, {
         status: "in-progress",
-        phase: toolName === "spawn_codex_planner_agent" ? "planning" : "implementation",
+        phase: tool.primaryUse === "planning" ? "planning" : "implementation",
         detail:
           [
             normalizedResult.toolReason ??
@@ -1064,12 +1065,10 @@ class Reactor {
     try {
       const comments = await this.github.listIssueComments(issue.number);
       const hasReferenceImages = issueHasReferenceImages(issue, comments);
-      const agentTool =
-        requestedAgentTool === "spawn_claude_ui_agent" && hasReferenceImages
-          ? "spawn_codex_issue_agent"
-          : requestedAgentTool;
+      const agentTool = requestedAgentTool;
       record.agentTool = agentTool;
       await ensureIssueWorktree(this.config, paths);
+      await this.runWorkspaceProvision(issue, paths, record.iteration + 1);
       const referenceImages = await writeIssueContext(this.config, issue, paths, {
         requestAuthority: record.requestAuthority,
         steeringUsername: record.steeringUsername,
@@ -1100,8 +1099,8 @@ class Reactor {
           existingRecord
             ? `Retry iteration ${record.iteration + 1} is running after the previous attempt ended without a final decision.`
             : "Full issue agent is reviewing the request and deciding the best product change.",
-          requestedAgentTool === "spawn_claude_ui_agent" && hasReferenceImages
-            ? "OpenReactor routed this run through Codex because reference images are attached and the current Claude CLI path does not yet support deterministic image attachments."
+          record.agentTool === "spawn_codex_ui_agent"
+            ? "OpenReactor will generate a UI design reference image with Codex before implementation."
             : "",
           referenceImages.length
             ? `Attached ${referenceImages.length} reference image${referenceImages.length === 1 ? "" : "s"} to the agent input.`
@@ -1129,6 +1128,73 @@ class Reactor {
         record,
         selectedTool: record.agentTool ?? requestedAgentTool
       });
+    }
+  }
+
+  private async runWorkspaceProvision(
+    issue: GitHubIssue,
+    paths: IssueRuntimePaths,
+    iteration: number
+  ): Promise<void> {
+    const command = this.config.workspacePolicy.provisionCommand?.trim();
+    if (!command) {
+      return;
+    }
+
+    const logPath = path.join(paths.runDir, "workspace-provision.log");
+    await appendRunActivity(paths.runDir, {
+      issueNumber: issue.number,
+      iteration,
+      kind: "workspace",
+      title: "Provisioning worktree",
+      message: "Running the workspace policy provision command before the agent starts.",
+      data: {
+        command,
+        policyPath: this.config.workspacePolicyPath
+      }
+    });
+
+    try {
+      const result = await runWorkspacePolicyCommand({
+        command,
+        cwd: paths.worktreePath,
+        env: this.config.workspacePolicy.env,
+        phase: "provision",
+        policyPath: this.config.workspacePolicyPath,
+        issueNumber: issue.number,
+        branchName: paths.branchName,
+        runDir: paths.runDir
+      });
+      await fs.writeFile(
+        logPath,
+        [result.stdout, result.stderr].filter(Boolean).join("\n"),
+        "utf8"
+      );
+      await appendRunActivity(paths.runDir, {
+        issueNumber: issue.number,
+        iteration,
+        kind: "workspace",
+        title: "Worktree provisioned",
+        message: "Workspace policy provision command completed.",
+        data: {
+          logPath
+        }
+      });
+    } catch (error) {
+      await fs.writeFile(logPath, formatError(error), "utf8").catch(() => {});
+      await appendRunActivity(paths.runDir, {
+        issueNumber: issue.number,
+        iteration,
+        kind: "workspace",
+        level: "error",
+        title: "Workspace provisioning failed",
+        message: formatError(error),
+        data: {
+          command,
+          logPath
+        }
+      });
+      throw error;
     }
   }
 
@@ -1586,18 +1652,16 @@ class Reactor {
     }
 
     const providerLabels = uniqueProviderLabels(triedTools);
-    if (!providerLabels.includes("Codex")) {
-      providerLabels.push("Codex");
-    }
-    if (!providerLabels.includes("Claude")) {
-      providerLabels.push("Claude");
-    }
+    const providerSummary =
+      providerLabels.length > 1
+        ? `${providerLabels.join(" and ")} both appear unavailable`
+        : `${providerLabels[0] ?? "The selected AI provider"} appears unavailable`;
 
     record.agentTool = preferredToolName;
     record.providerFallbackToolsTried = [];
     record.status = "failed";
     record.lastError =
-      `${phase}: both AI providers appear unavailable. Last provider outage: ${outageReason}.`;
+      `${phase}: ${providerSummary}. Last provider outage: ${outageReason}.`;
     record.updatedAt = new Date().toISOString();
     record.lastHeartbeatAt = record.updatedAt;
     await writeRunRecord(issueRuntimePaths(this.config, issue.number), record);
@@ -1608,14 +1672,12 @@ class Reactor {
       status: "queued",
       phase: "paused",
       iteration: record.iteration,
-      detail:
-        `${providerLabels.join(" and ")} both appear unavailable, so OpenReactor paused this ` +
-        `issue until a provider recovers.`
+      detail: `${providerSummary}, so OpenReactor paused this issue until provider availability recovers.`
     });
     await this.github.createComment(
       issue.number,
       [
-        "OpenReactor paused this issue because both AI providers appear unavailable.",
+        `OpenReactor paused this issue because ${providerSummary}.`,
         "",
         `Phase: ${phase}`,
         `Last provider outage signal: ${outageReason}`,

--- a/reactor/repo-state.ts
+++ b/reactor/repo-state.ts
@@ -2,6 +2,14 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 export const REPO_STATE_DIR = path.join(".openreactor", "repo");
+export const REQUIRED_REPO_STATE_DOCS = [
+  "README.md",
+  "PRODUCT_SPEC.md",
+  "PRODUCT_CONSTITUTION.md",
+  "TRIAGE_POLICY.md",
+  "ROADMAP.md",
+  "MEMORY.md"
+] as const;
 export const REPO_RUNTIME_GITIGNORE_RULES = [
   ".openreactor/*",
   "!.openreactor/repo/",
@@ -29,6 +37,13 @@ export interface RepoStateSeeds {
   issues?: RepoStateSeedIssue[];
 }
 
+export interface RepoStateReadiness {
+  ready: boolean;
+  repoStateDir: string;
+  missing: string[];
+  placeholders: string[];
+}
+
 export async function resolveRepoDocumentationPaths(repoRoot: string): Promise<RepoDocumentationPaths> {
   return {
     readme: await preferRepoStateDoc(repoRoot, "README.md"),
@@ -38,6 +53,32 @@ export async function resolveRepoDocumentationPaths(repoRoot: string): Promise<R
     roadmap: await preferRepoStateDoc(repoRoot, "ROADMAP.md"),
     memory: await preferRepoStateDoc(repoRoot, "MEMORY.md"),
     uiSystem: await resolveOptionalRepoDoc(repoRoot, "UI_SYSTEM.md")
+  };
+}
+
+export async function checkRepoStateReadiness(repoRoot: string): Promise<RepoStateReadiness> {
+  const repoStateDir = path.join(repoRoot, REPO_STATE_DIR);
+  const missing: string[] = [];
+  const placeholders: string[] = [];
+
+  for (const fileName of REQUIRED_REPO_STATE_DOCS) {
+    const filePath = path.join(repoStateDir, fileName);
+    const content = await readOptionalText(filePath);
+    if (content === null) {
+      missing.push(fileName);
+      continue;
+    }
+
+    if (isLikelyBootstrapPlaceholder(fileName, content)) {
+      placeholders.push(fileName);
+    }
+  }
+
+  return {
+    ready: missing.length === 0 && placeholders.length === 0,
+    repoStateDir,
+    missing,
+    placeholders
   };
 }
 
@@ -358,6 +399,11 @@ const BOOTSTRAP_PLACEHOLDER_MARKERS: Record<string, string[]> = {
     "State what this product is meant to optimize for.",
     "- List the durable product rules agents should treat as binding.",
     "- Note what kinds of requests should be rejected."
+  ],
+  "TRIAGE_POLICY.md": [
+    "This file contains repo-specific decision policy for triage and issue agents.",
+    "- Define what counts as `main` for this repo.",
+    "- Explain what kinds of requests are usually core product work for this repo."
   ],
   "ROADMAP.md": [
     "- Add the current priorities for this repo.",

--- a/reactor/runner.ts
+++ b/reactor/runner.ts
@@ -128,6 +128,10 @@ export interface IssueRuntimePaths {
   triageLogPath: string;
   contextPath: string;
   referenceImagesDir: string;
+  uiDesignPromptPath: string;
+  uiDesignLogPath: string;
+  uiDesignBriefPath: string;
+  uiDesignImagePath: string;
   progressPath: string;
   tasksPath: string;
   planPath: string;
@@ -188,6 +192,10 @@ export function issueRuntimePaths(config: OrchestratorConfig, issueNumber: numbe
     triageLogPath: path.join(runDir, "triage.log"),
     contextPath: path.join(runDir, "context.md"),
     referenceImagesDir: path.join(runDir, "reference-images"),
+    uiDesignPromptPath: path.join(runDir, "ui-design-prepass.prompt.md"),
+    uiDesignLogPath: path.join(runDir, "ui-design-prepass.log"),
+    uiDesignBriefPath: path.join(runDir, "ui-design-brief.md"),
+    uiDesignImagePath: path.join(runDir, "ui-design-reference.svg"),
     progressPath: path.join(runDir, "progress.md"),
     tasksPath: path.join(runDir, "tasks.md"),
     planPath: path.join(runDir, "plan.json")
@@ -289,6 +297,8 @@ export async function writeIssueContext(
     `- Progress log: ${relativeFromRepo(config, paths.progressPath)}`,
     `- Task tracker: ${relativeFromRepo(config, paths.tasksPath)}`,
     `- Plan file: ${relativeFromRepo(config, paths.planPath)}`,
+    `- UI design reference image: ${relativeFromRepo(config, paths.uiDesignImagePath)}`,
+    `- UI design brief: ${relativeFromRepo(config, paths.uiDesignBriefPath)}`,
     `- Run state: ${relativeFromRepo(config, paths.runFilePath)}`,
     `- Reference images: ${relativeFromRepo(config, paths.referenceImagesDir)}`,
     "",
@@ -299,6 +309,7 @@ export async function writeIssueContext(
     `- ${relativeFromWorktree(paths, repoDocs.productConstitution)}`,
     ...(repoDocs.triagePolicy ? [`- ${relativeFromWorktree(paths, repoDocs.triagePolicy)}`] : []),
     `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "OPENREACTOR_WORKFLOW.md"))}`,
+    `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "STACK_WORKFLOWS.md"))}`,
     `- ${relativeFromWorktree(paths, repoDocs.roadmap)}`,
     `- ${relativeFromWorktree(paths, repoDocs.memory)}`,
     `- ${relativeFromWorktree(paths, repoDocs.readme)}`
@@ -470,11 +481,19 @@ export async function spawnIssueAgent(input: {
   if (tool.name === "spawn_claude_issue_agent") {
     return spawnClaudeIssueAgent(input);
   }
-  if (tool.provider === "claude") {
-    return spawnClaudeUiIssueAgent(input);
+  if (tool.name === "spawn_codex_ui_agent") {
+    return spawnCodexUiIssueAgent(input);
   }
 
   return spawnCodexIssueAgent(input);
+}
+
+interface CodexAgentSpawnOptions {
+  toolName: AgentToolName;
+  model: string;
+  reasoningEffort: string;
+  serviceTier: string;
+  imagePaths?: string[];
 }
 
 async function spawnCodexIssueAgent(input: {
@@ -485,103 +504,13 @@ async function spawnCodexIssueAgent(input: {
   githubToken: string;
   referenceImages?: RunReferenceImage[];
 }): Promise<ActiveRun> {
-  const { config, issue, paths, githubToken } = input;
-  const iteration = input.record.iteration + 1;
-  const schemaPath = path.join(config.engineRoot, "reactor", "agent-result.schema.json");
-  const resultPath = path.join(paths.runDir, `iteration-${iteration}.result.json`);
-  const logPath = path.join(paths.runDir, `iteration-${iteration}.log`);
-  const promptPath = path.join(paths.runDir, `iteration-${iteration}.prompt.md`);
-  const prompt = await buildAgentPrompt(
-    config,
-    issue,
-    paths,
-    iteration,
-    "spawn_codex_issue_agent",
-    input.record.requestAuthority ?? "feedback",
-    input.record.steeringUsername ?? null
-  );
-
-  await fs.writeFile(promptPath, prompt, "utf8");
-
-  const args = buildCodexArgs({
-    model: config.agentModel,
-    reasoningEffort: config.agentReasoningEffort,
-    serviceTier: config.agentServiceTier,
-    fullAccess: true,
-    outputSchemaPath: schemaPath,
-    outputPath: resultPath,
+  return spawnCodexAgent(input, {
+    toolName: "spawn_codex_issue_agent",
+    model: input.config.agentModel,
+    reasoningEffort: input.config.agentReasoningEffort,
+    serviceTier: input.config.agentServiceTier,
     imagePaths: input.referenceImages?.map((image) => image.localPath)
   });
-
-  const child = spawn("codex", args, {
-    cwd: paths.worktreePath,
-    env: {
-      ...process.env,
-      GH_TOKEN: githubToken,
-      GITHUB_TOKEN: githubToken,
-      OPENREACTOR_REPO_OWNER: config.owner,
-      OPENREACTOR_REPO_NAME: config.repo,
-      OPENREACTOR_ENGINE_ROOT: config.engineRoot,
-      OPENREACTOR_ENGINE_TOOL: path.join(config.engineRoot, "reactor", "tool.ts"),
-      OPENREACTOR_ISSUE_NUMBER: String(issue.number),
-      OPENREACTOR_ISSUE_URL: issue.html_url,
-      OPENREACTOR_RUN_DIR: paths.runDir,
-      OPENREACTOR_PLAN_PATH: paths.planPath,
-      OPENREACTOR_PROGRESS_PATH: paths.progressPath,
-      OPENREACTOR_TASKS_PATH: paths.tasksPath,
-      OPENREACTOR_BRANCH_NAME: paths.branchName,
-      AGENT_BROWSER_SESSION: `openreactor-issue-${issue.number}`,
-      AGENT_BROWSER_PROFILE: path.join(paths.runDir, "agent-browser-profile"),
-      AGENT_BROWSER_DOWNLOAD_PATH: path.join(paths.runDir, "agent-browser-downloads"),
-      AGENT_BROWSER_CONTENT_BOUNDARIES: "1",
-      AGENT_BROWSER_MAX_OUTPUT: "50000",
-      PATH: `${path.join(paths.worktreePath, "node_modules", ".bin")}${path.delimiter}${process.env.PATH ?? ""}`
-    },
-    stdio: ["pipe", "pipe", "pipe"]
-  });
-
-  child.stdin.end(prompt);
-
-  await attachProcessLogging(child, logPath);
-
-  const record: RunRecord = {
-    ...input.record,
-    agentTool: "spawn_codex_issue_agent",
-    status: "running",
-    iteration,
-    startFailureCount: 0,
-    updatedAt: new Date().toISOString(),
-    lastHeartbeatAt: new Date().toISOString(),
-    lastError: ""
-  };
-  await writeRunRecord(paths, record);
-
-  const heartbeatTimer = setInterval(() => {
-    record.updatedAt = new Date().toISOString();
-    record.lastHeartbeatAt = record.updatedAt;
-    void writeRunRecord(paths, record);
-  }, 10_000);
-
-  return {
-    issue,
-    record,
-    process: child,
-    heartbeatTimer,
-    resultPath,
-    logPath,
-    startedAt: Date.now(),
-    executionTemplate: {
-      providerKey: "codex",
-      providerLabel: providerLabelFor("codex"),
-      model: config.agentModel,
-      reasoningEffort: config.agentReasoningEffort,
-      serviceTier: config.agentServiceTier ?? null,
-      toolName: "spawn_codex_issue_agent",
-      toolLabel: getAgentTool("spawn_codex_issue_agent").label,
-      primaryUse: getAgentTool("spawn_codex_issue_agent").primaryUse
-    },
-    parseResult: () => parseAgentResult(resultPath)
-  };
 }
 
 async function spawnCodexPlannerAgent(input: {
@@ -592,6 +521,47 @@ async function spawnCodexPlannerAgent(input: {
   githubToken: string;
   referenceImages?: RunReferenceImage[];
 }): Promise<ActiveRun> {
+  return spawnCodexAgent(input, {
+    toolName: "spawn_codex_planner_agent",
+    model: input.config.plannerModel,
+    reasoningEffort: input.config.plannerReasoningEffort,
+    serviceTier: input.config.plannerServiceTier,
+    imagePaths: input.referenceImages?.map((image) => image.localPath)
+  });
+}
+
+async function spawnCodexUiIssueAgent(input: {
+  config: OrchestratorConfig;
+  issue: GitHubIssue;
+  paths: IssueRuntimePaths;
+  record: RunRecord;
+  githubToken: string;
+  referenceImages?: RunReferenceImage[];
+}): Promise<ActiveRun> {
+  const designImagePaths = await prepareCodexUiDesignReference(input);
+  return spawnCodexAgent(input, {
+    toolName: "spawn_codex_ui_agent",
+    model: input.config.codexUiModel,
+    reasoningEffort: input.config.codexUiReasoningEffort,
+    serviceTier: input.config.codexUiServiceTier,
+    imagePaths: [
+      ...designImagePaths,
+      ...(input.referenceImages?.map((image) => image.localPath) ?? [])
+    ]
+  });
+}
+
+async function spawnCodexAgent(
+  input: {
+    config: OrchestratorConfig;
+    issue: GitHubIssue;
+    paths: IssueRuntimePaths;
+    record: RunRecord;
+    githubToken: string;
+    referenceImages?: RunReferenceImage[];
+  },
+  options: CodexAgentSpawnOptions
+): Promise<ActiveRun> {
   const { config, issue, paths, githubToken } = input;
   const iteration = input.record.iteration + 1;
   const schemaPath = path.join(config.engineRoot, "reactor", "agent-result.schema.json");
@@ -603,7 +573,7 @@ async function spawnCodexPlannerAgent(input: {
     issue,
     paths,
     iteration,
-    "spawn_codex_planner_agent",
+    options.toolName,
     input.record.requestAuthority ?? "feedback",
     input.record.steeringUsername ?? null
   );
@@ -611,34 +581,18 @@ async function spawnCodexPlannerAgent(input: {
   await fs.writeFile(promptPath, prompt, "utf8");
 
   const args = buildCodexArgs({
-    model: config.plannerModel,
-    reasoningEffort: config.plannerReasoningEffort,
-    serviceTier: config.plannerServiceTier,
+    model: options.model,
+    reasoningEffort: options.reasoningEffort,
+    serviceTier: options.serviceTier,
     fullAccess: true,
     outputSchemaPath: schemaPath,
     outputPath: resultPath,
-    imagePaths: input.referenceImages?.map((image) => image.localPath)
+    imagePaths: options.imagePaths
   });
 
   const child = spawn("codex", args, {
     cwd: paths.worktreePath,
-    env: {
-      ...process.env,
-      GH_TOKEN: githubToken,
-      GITHUB_TOKEN: githubToken,
-      OPENREACTOR_REPO_OWNER: config.owner,
-      OPENREACTOR_REPO_NAME: config.repo,
-      OPENREACTOR_ENGINE_ROOT: config.engineRoot,
-      OPENREACTOR_ENGINE_TOOL: path.join(config.engineRoot, "reactor", "tool.ts"),
-      OPENREACTOR_ISSUE_NUMBER: String(issue.number),
-      OPENREACTOR_ISSUE_URL: issue.html_url,
-      OPENREACTOR_RUN_DIR: paths.runDir,
-      OPENREACTOR_PLAN_PATH: paths.planPath,
-      OPENREACTOR_PROGRESS_PATH: paths.progressPath,
-      OPENREACTOR_TASKS_PATH: paths.tasksPath,
-      OPENREACTOR_BRANCH_NAME: paths.branchName,
-      PATH: `${path.join(paths.worktreePath, "node_modules", ".bin")}${path.delimiter}${process.env.PATH ?? ""}`
-    },
+    env: buildAgentEnv(config, issue, paths, githubToken),
     stdio: ["pipe", "pipe", "pipe"]
   });
 
@@ -648,7 +602,7 @@ async function spawnCodexPlannerAgent(input: {
 
   const record: RunRecord = {
     ...input.record,
-    agentTool: "spawn_codex_planner_agent",
+    agentTool: options.toolName,
     status: "running",
     iteration,
     startFailureCount: 0,
@@ -675,25 +629,73 @@ async function spawnCodexPlannerAgent(input: {
     executionTemplate: {
       providerKey: "codex",
       providerLabel: providerLabelFor("codex"),
-      model: config.plannerModel,
-      reasoningEffort: config.plannerReasoningEffort,
-      serviceTier: config.plannerServiceTier ?? null,
-      toolName: "spawn_codex_planner_agent",
-      toolLabel: getAgentTool("spawn_codex_planner_agent").label,
-      primaryUse: getAgentTool("spawn_codex_planner_agent").primaryUse
+      model: options.model,
+      reasoningEffort: options.reasoningEffort,
+      serviceTier: options.serviceTier || null,
+      toolName: options.toolName,
+      toolLabel: getAgentTool(options.toolName).label,
+      primaryUse: getAgentTool(options.toolName).primaryUse
     },
     parseResult: () => parseAgentResult(resultPath)
   };
 }
 
-async function spawnClaudeUiIssueAgent(input: {
+async function prepareCodexUiDesignReference(input: {
   config: OrchestratorConfig;
   issue: GitHubIssue;
   paths: IssueRuntimePaths;
   record: RunRecord;
   githubToken: string;
-}): Promise<ActiveRun> {
-  return spawnClaudeAgent(input, "spawn_claude_ui_agent");
+  referenceImages?: RunReferenceImage[];
+}): Promise<string[]> {
+  const { config, issue, paths, githubToken } = input;
+  await fs.mkdir(paths.runDir, { recursive: true });
+
+  const prompt = await buildUiDesignPrepassPrompt(
+    config,
+    issue,
+    paths,
+    input.record,
+    input.referenceImages ?? []
+  );
+  await fs.writeFile(paths.uiDesignPromptPath, prompt, "utf8");
+
+  const child = spawn("codex", buildCodexExecArgs({
+    model: config.uiDesignModel,
+    reasoningEffort: config.uiDesignReasoningEffort,
+    serviceTier: config.uiDesignServiceTier,
+    fullAccess: true,
+    imagePaths: input.referenceImages?.map((image) => image.localPath)
+  }), {
+    cwd: paths.worktreePath,
+    env: buildAgentEnv(config, issue, paths, githubToken, {
+      OPENREACTOR_UI_DESIGN_IMAGE_PATH: paths.uiDesignImagePath,
+      OPENREACTOR_UI_DESIGN_BRIEF_PATH: paths.uiDesignBriefPath
+    }),
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+
+  child.stdin.end(prompt);
+  await attachProcessLogging(child, paths.uiDesignLogPath);
+
+  const exitCode = await waitForExit(child);
+  if (exitCode !== 0) {
+    throw new Error(`Codex UI design prepass exited with code ${exitCode ?? "unknown"}`);
+  }
+
+  const imageExists = await pathExists(paths.uiDesignImagePath);
+  const briefExists = await pathExists(paths.uiDesignBriefPath);
+  if (!imageExists || !briefExists) {
+    throw new Error(
+      [
+        "Codex UI design prepass did not produce the required artifacts.",
+        imageExists ? "" : `Missing image: ${paths.uiDesignImagePath}`,
+        briefExists ? "" : `Missing brief: ${paths.uiDesignBriefPath}`
+      ].filter(Boolean).join(" ")
+    );
+  }
+
+  return [paths.uiDesignImagePath];
 }
 
 async function spawnClaudeIssueAgent(input: {
@@ -746,31 +748,15 @@ async function spawnClaudeAgent(
   await fs.writeFile(promptPath, prompt, "utf8");
 
   const args = buildClaudeArgs({
-    model: config.claudeUiModel,
-    effort: config.claudeUiEffort,
+    model: config.claudeModel,
+    effort: config.claudeEffort,
     schema,
     runDir: paths.runDir
   });
 
-  const child = spawn(config.claudeUiBin, args, {
+  const child = spawn(config.claudeBin, args, {
     cwd: paths.worktreePath,
-    env: {
-      ...process.env,
-      GH_TOKEN: githubToken,
-      GITHUB_TOKEN: githubToken,
-      OPENREACTOR_REPO_OWNER: config.owner,
-      OPENREACTOR_REPO_NAME: config.repo,
-      OPENREACTOR_ENGINE_ROOT: config.engineRoot,
-      OPENREACTOR_ENGINE_TOOL: path.join(config.engineRoot, "reactor", "tool.ts"),
-      OPENREACTOR_ISSUE_NUMBER: String(issue.number),
-      OPENREACTOR_ISSUE_URL: issue.html_url,
-      OPENREACTOR_RUN_DIR: paths.runDir,
-      OPENREACTOR_PLAN_PATH: paths.planPath,
-      OPENREACTOR_PROGRESS_PATH: paths.progressPath,
-      OPENREACTOR_TASKS_PATH: paths.tasksPath,
-      OPENREACTOR_BRANCH_NAME: paths.branchName,
-      PATH: `${path.join(paths.worktreePath, "node_modules", ".bin")}${path.delimiter}${process.env.PATH ?? ""}`
-    },
+    env: buildAgentEnv(config, issue, paths, githubToken),
     stdio: ["pipe", "pipe", "pipe"]
   });
 
@@ -807,8 +793,8 @@ async function spawnClaudeAgent(
     executionTemplate: {
       providerKey: "claude",
       providerLabel: providerLabelFor("claude"),
-      model: config.claudeUiModel,
-      reasoningEffort: config.claudeUiEffort,
+      model: config.claudeModel,
+      reasoningEffort: config.claudeEffort,
       serviceTier: null,
       toolName,
       toolLabel: getAgentTool(toolName).label,
@@ -858,6 +844,7 @@ export async function runIssueTriage(input: {
     cwd: config.repoRoot,
     env: {
       ...process.env,
+      ...(config.workspacePolicy.env ?? {}),
       GH_TOKEN: githubToken,
       GITHUB_TOKEN: githubToken,
       OPENREACTOR_REPO_OWNER: config.owner,
@@ -933,6 +920,63 @@ export async function finalizeIssueAgentRun(input: {
   };
 }
 
+async function buildUiDesignPrepassPrompt(
+  config: OrchestratorConfig,
+  issue: GitHubIssue,
+  paths: IssueRuntimePaths,
+  record: RunRecord,
+  referenceImages: RunReferenceImage[]
+): Promise<string> {
+  const repoDocs = await resolveRepoDocumentationPaths(paths.worktreePath);
+  const uiSystemPath = repoDocs.uiSystem ?? path.join(config.engineRoot, "UI_SYSTEM.md");
+
+  return [
+    `You are OpenReactor's Codex UI design prepass for GitHub issue #${issue.number}.`,
+    "",
+    "Your output will be fed as an image attachment into the frontend implementation agent. Spend the reasoning budget on product interpretation, visual hierarchy, responsive behavior, and concrete UI states before creating the artifact.",
+    "",
+    "Read these files first:",
+    `- ${relativeFromWorktree(paths, uiSystemPath)}`,
+    `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "product-context.md"))}`,
+    `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "ui-agent.md"))}`,
+    `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "STACK_WORKFLOWS.md"))}`,
+    `- ${relativeFromWorktree(paths, repoDocs.productSpec)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.productConstitution)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.roadmap)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.memory)}`,
+    `- ${relativeFromWorktree(paths, repoDocs.readme)}`,
+    `- ${relativeFromWorktree(paths, paths.contextPath)}`,
+    "",
+    "Issue context:",
+    `- Issue URL: ${issue.html_url}`,
+    `- Title: ${issue.title}`,
+    `- Request authority: ${record.requestAuthority ?? "feedback"}`,
+    `- Target surface: ${record.targetSurface ?? "unknown"}`,
+    `- Sensitivity: ${record.sensitivity ?? "unknown"}`,
+    "",
+    "Reference images already attached to the issue:",
+    formatReferenceImageContext(config, paths, referenceImages),
+    "",
+    "Create these exact artifacts:",
+    `- Image: ${paths.uiDesignImagePath}`,
+    `- Brief: ${paths.uiDesignBriefPath}`,
+    "",
+    "Image artifact requirements:",
+    "- Write a single self-contained SVG image file. It should be a concrete product screen or flow state, not a moodboard.",
+    "- Show the layout, hierarchy, navigation, primary and secondary actions, component density, and relevant empty/loading/error states where they affect the implementation.",
+    "- Include exact visible labels when they materially affect implementation, and keep all text legible.",
+    "- Respect existing product constraints and UI system rules. If issue reference images conflict with your generated direction, the issue reference images win.",
+    "- Do not use external image URLs, secrets, private tokens, or brand assets that are not already present in the repo.",
+    "",
+    "Brief requirements:",
+    "- Summarize the product intent, target screen/state, key layout decisions, responsive behavior, and interaction states.",
+    "- List implementation acceptance criteria the frontend agent should verify in browser.",
+    "- Call out any repo constraints or uncertainties the implementation agent should resolve in code.",
+    "",
+    "Do not edit product code, docs, tests, package files, git state, or GitHub. Only create or overwrite the two design artifacts above."
+  ].join("\n");
+}
+
 async function buildAgentPrompt(
   config: OrchestratorConfig,
   issue: GitHubIssue,
@@ -946,16 +990,19 @@ async function buildAgentPrompt(
   const trustedSubmitter = getTrustedSubmitterSignal(config, issue);
   const repoDocs = await resolveRepoDocumentationPaths(paths.worktreePath);
   const extraFiles =
-    agentTool === "spawn_claude_ui_agent"
+    agentTool === "spawn_codex_ui_agent"
       ? [`- ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "ui-agent.md"))}`]
       : agentTool === "spawn_codex_planner_agent" || agentTool === "spawn_claude_planner_agent"
         ? [`- ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "planner-agent.md"))}`]
         : [];
   const toolRules =
-    agentTool === "spawn_claude_ui_agent"
+    agentTool === "spawn_codex_ui_agent"
       ? [
           `- This issue was dispatched via ${tool.label}. Treat it as a UI-heavy task unless the code proves otherwise.`,
           `- Use ${relativeFromWorktree(paths, path.join(config.engineRoot, "prompts", "ui-agent.md"))} as your frontend design skill equivalent while making design decisions.`,
+          `- Inspect the generated design reference image at ${relativeFromWorktree(paths, paths.uiDesignImagePath)} and the design brief at ${relativeFromWorktree(paths, paths.uiDesignBriefPath)} before changing UI code.`,
+          "- Treat the generated design image as strong design direction for layout, hierarchy, density, and interaction states, while still adapting it to the existing codebase and accessibility constraints.",
+          "- If issue-provided reference images conflict with the generated design image, prioritize the issue-provided reference images.",
           "- Prefer tight, polished UI work over broad refactors when solving the issue."
         ]
       : agentTool === "spawn_claude_planner_agent"
@@ -999,6 +1046,7 @@ async function buildAgentPrompt(
     `- ${relativeFromWorktree(paths, repoDocs.memory)}`,
     `- ${relativeFromWorktree(paths, repoDocs.readme)}`,
     `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "OPENREACTOR_WORKFLOW.md"))}`,
+    `- ${relativeFromWorktree(paths, path.join(config.engineRoot, "STACK_WORKFLOWS.md"))}`,
     ...extraFiles,
     `- ${relativeFromWorktree(paths, paths.contextPath)}`,
     `- ${relativeFromWorktree(paths, paths.planPath)}`,
@@ -1096,6 +1144,7 @@ async function buildTriagePrompt(
     `- ${relativeFromRepo(config, repoDocs.productConstitution)}`,
     ...(repoDocs.triagePolicy ? [`- ${relativeFromRepo(config, repoDocs.triagePolicy)}`] : []),
     `- ${relativeFromRepo(config, path.join(config.engineRoot, "OPENREACTOR_WORKFLOW.md"))}`,
+    `- ${relativeFromRepo(config, path.join(config.engineRoot, "STACK_WORKFLOWS.md"))}`,
     `- ${relativeFromRepo(config, repoDocs.roadmap)}`,
     `- ${relativeFromRepo(config, repoDocs.memory)}`,
     `- ${relativeFromRepo(config, repoDocs.readme)}`,
@@ -1248,6 +1297,41 @@ function formatRecentDiscussion(comments: GitHubIssueComment[]): string {
 
 function providerLabelFor(provider: "codex" | "claude"): string {
   return provider === "claude" ? "Anthropic" : "OpenAI";
+}
+
+function buildAgentEnv(
+  config: OrchestratorConfig,
+  issue: GitHubIssue,
+  paths: IssueRuntimePaths,
+  githubToken: string,
+  extraEnv: Record<string, string> = {}
+): NodeJS.ProcessEnv {
+  const inheritedPath = config.workspacePolicy.env?.PATH ?? process.env.PATH ?? "";
+
+  return {
+    ...process.env,
+    ...(config.workspacePolicy.env ?? {}),
+    GH_TOKEN: githubToken,
+    GITHUB_TOKEN: githubToken,
+    OPENREACTOR_REPO_OWNER: config.owner,
+    OPENREACTOR_REPO_NAME: config.repo,
+    OPENREACTOR_ENGINE_ROOT: config.engineRoot,
+    OPENREACTOR_ENGINE_TOOL: path.join(config.engineRoot, "reactor", "tool.ts"),
+    OPENREACTOR_ISSUE_NUMBER: String(issue.number),
+    OPENREACTOR_ISSUE_URL: issue.html_url,
+    OPENREACTOR_RUN_DIR: paths.runDir,
+    OPENREACTOR_PLAN_PATH: paths.planPath,
+    OPENREACTOR_PROGRESS_PATH: paths.progressPath,
+    OPENREACTOR_TASKS_PATH: paths.tasksPath,
+    OPENREACTOR_BRANCH_NAME: paths.branchName,
+    AGENT_BROWSER_SESSION: `openreactor-issue-${issue.number}`,
+    AGENT_BROWSER_PROFILE: path.join(paths.runDir, "agent-browser-profile"),
+    AGENT_BROWSER_DOWNLOAD_PATH: path.join(paths.runDir, "agent-browser-downloads"),
+    AGENT_BROWSER_CONTENT_BOUNDARIES: "1",
+    AGENT_BROWSER_MAX_OUTPUT: "50000",
+    ...extraEnv,
+    PATH: `${path.join(paths.worktreePath, "node_modules", ".bin")}${path.delimiter}${inheritedPath}`
+  };
 }
 
 function buildExecutionMetadata(
@@ -1441,6 +1525,24 @@ function buildCodexArgs(input: {
   outputPath: string;
   imagePaths?: string[];
 }): string[] {
+  const args = buildCodexExecArgs(input);
+  args.push(
+    "--output-schema",
+    input.outputSchemaPath,
+    "-o",
+    input.outputPath
+  );
+
+  return args;
+}
+
+function buildCodexExecArgs(input: {
+  model: string;
+  reasoningEffort: string;
+  serviceTier: string;
+  fullAccess: boolean;
+  imagePaths?: string[];
+}): string[] {
   const args = [
     "-m",
     input.model,
@@ -1465,11 +1567,7 @@ function buildCodexArgs(input: {
   args.push(
     "exec",
     "-",
-    "--skip-git-repo-check",
-    "--output-schema",
-    input.outputSchemaPath,
-    "-o",
-    input.outputPath
+    "--skip-git-repo-check"
   );
 
   return args;

--- a/reactor/tool.ts
+++ b/reactor/tool.ts
@@ -8,7 +8,7 @@ import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { loadConfig } from "./config";
 import { buildExecutionFooter, renderBodyWithExecutionFooter } from "./execution-footer";
-import { initializeRepoState, REPO_STATE_DIR } from "./repo-state";
+import { checkRepoStateReadiness, initializeRepoState, REPO_STATE_DIR } from "./repo-state";
 
 const execFileAsync = promisify(execFile);
 
@@ -37,6 +37,11 @@ async function main(): Promise<void> {
 
   if (command === "init-repo-state") {
     await initRepoState(rest);
+    return;
+  }
+
+  if (command === "check-genesis") {
+    await checkGenesis(rest);
     return;
   }
 
@@ -252,6 +257,26 @@ async function initRepoState(args: string[]): Promise<void> {
       2
     )
   );
+}
+
+async function checkGenesis(args: string[]): Promise<void> {
+  const cwd = path.resolve(optionalStringArg(args, "--cwd") || process.cwd());
+  const readiness = await checkRepoStateReadiness(cwd);
+
+  console.log(
+    JSON.stringify(
+      {
+        repoRoot: cwd,
+        ...readiness
+      },
+      null,
+      2
+    )
+  );
+
+  if (!readiness.ready) {
+    process.exitCode = 1;
+  }
 }
 
 async function startInstance(args: string[]): Promise<void> {
@@ -628,6 +653,7 @@ function printHelp(): void {
       "  ensure-pr --issue <number> --branch <branch> --title <title> --body-file <file> [--base main] [--cwd <dir>] [--merge-method squash] [--no-auto-merge]",
       "  coauthor-trailer --username <github-login>",
       "  init-repo-state [--cwd <dir>] [--repo-name <name>]",
+      "  check-genesis [--cwd <dir>]",
       "  start-instance [--cwd <dir>] [--owner <owner>] [--repo <repo>] [--instance-name <name>] [--status-port <port>] [--status-token <token>]",
       "",
       "Notes:",
@@ -635,6 +661,7 @@ function printHelp(): void {
       "  Auto-merge is enabled by default. Pass --no-auto-merge when the PR should wait for human or manual review.",
       "  coauthor-trailer resolves a GitHub login to a GitHub-recognized Co-authored-by trailer using the account's user id.",
       "  init-repo-state creates the committed repo-local product steering files under .openreactor/repo/.",
+      "  check-genesis verifies that the repo-local product steering files are present and no longer look like bootstrap placeholders.",
       "  start-instance writes a repo-specific env file and starts transient reactor, watchdog, and local status services for that repo."
     ].join("\n")
   );

--- a/reactor/triage-result.schema.json
+++ b/reactor/triage-result.schema.json
@@ -50,7 +50,7 @@
         null,
         "spawn_codex_issue_agent",
         "spawn_codex_planner_agent",
-        "spawn_claude_ui_agent"
+        "spawn_codex_ui_agent"
       ]
     },
     "toolReason": {

--- a/tests/homepage.pw.ts
+++ b/tests/homepage.pw.ts
@@ -288,9 +288,9 @@ test.beforeEach(async ({ page }) => {
                   issueUrl: "https://github.com/rayzhudev/openreactor/issues/201",
                   branchName: "openreactor/issue-201",
                   iteration: 2,
-                  toolName: "spawn_claude_ui_agent",
-                  toolLabel: "Claude UI agent",
-                  provider: "claude",
+                  toolName: "spawn_codex_ui_agent",
+                  toolLabel: "Codex UI agent",
+                  provider: "codex",
                   primaryUse: "ui",
                   updatedAt: "2026-03-12T11:58:00.000Z",
                   lastHeartbeatAt: "2026-03-12T11:59:00.000Z",
@@ -390,12 +390,12 @@ test.beforeEach(async ({ page }) => {
             {
               id: "openreactor:actor:201",
               kind: "agent",
-              label: "Claude UI agent",
+              label: "Codex UI agent",
               role: "ui",
               status: "working",
               currentNodeId: "execution",
               currentItemId: "openreactor:issue:201",
-              provider: "claude",
+              provider: "codex",
               startedAt: "2026-03-12T11:50:00.000Z",
               lastHeartbeatAt: "2026-03-12T11:59:00.000Z",
               extensions: {
@@ -405,8 +405,8 @@ test.beforeEach(async ({ page }) => {
                   issueUrl: "https://github.com/rayzhudev/openreactor/issues/201",
                   branchName: "openreactor/issue-201",
                   iteration: 2,
-                  toolName: "spawn_claude_ui_agent",
-                  toolLabel: "Claude UI agent",
+                  toolName: "spawn_codex_ui_agent",
+                  toolLabel: "Codex UI agent",
                   primaryUse: "ui",
                   updatedAt: "2026-03-12T11:58:00.000Z",
                   rawStatus: "running"
@@ -549,7 +549,7 @@ test.beforeEach(async ({ page }) => {
               level: "info",
               subjectType: "item",
               subjectId: "openreactor:issue:201",
-              message: "Claude UI agent is actively iterating on the queue cards.",
+              message: "Codex UI agent is actively iterating on the queue cards.",
               extensions: {
                 openreactor: {
                   title: "Agent heartbeat",
@@ -616,7 +616,7 @@ test("renders the redesign and submits a request through the mocked API", async 
   });
   expect(factoryNodeCount).toBeGreaterThan(0);
   await expect(page.locator("#openreactor-live-agents")).toContainText("Polish the public queue cards");
-  await expect(page.locator("#openreactor-live-agents")).toContainText("Claude UI agent");
+  await expect(page.locator("#openreactor-live-agents")).toContainText("Codex UI agent");
   await expect(page.locator("#openreactor-live-blockers")).toContainText("Maintainer action");
   await expect(page.locator("#openreactor-live-blockers")).toContainText("schema_mismatch");
 

--- a/tests/repo-state.spec.ts
+++ b/tests/repo-state.spec.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  REPO_STATE_DIR,
+  REQUIRED_REPO_STATE_DOCS,
+  checkRepoStateReadiness,
+  initializeRepoState
+} from "../reactor/repo-state";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+});
+
+describe("repo state readiness", () => {
+  test("reports missing required Genesis documents", async () => {
+    const repoRoot = createTempRepoRoot();
+    const readiness = await checkRepoStateReadiness(repoRoot);
+
+    expect(readiness.ready).toBe(false);
+    expect(readiness.missing).toEqual([...REQUIRED_REPO_STATE_DOCS]);
+    expect(readiness.placeholders).toEqual([]);
+  });
+
+  test("reports bootstrap placeholders as not ready", async () => {
+    const repoRoot = createTempRepoRoot();
+    await initializeRepoState(repoRoot, "Example Product");
+
+    const readiness = await checkRepoStateReadiness(repoRoot);
+
+    expect(readiness.ready).toBe(false);
+    expect(readiness.missing).toEqual([]);
+    expect(readiness.placeholders).toContain("README.md");
+    expect(readiness.placeholders).toContain("PRODUCT_SPEC.md");
+  });
+
+  test("accepts concrete repo-local product steering docs", async () => {
+    const repoRoot = createTempRepoRoot();
+    const repoStateDir = path.join(repoRoot, REPO_STATE_DIR);
+    await fs.mkdir(repoStateDir, { recursive: true });
+
+    for (const fileName of REQUIRED_REPO_STATE_DOCS) {
+      await fs.writeFile(
+        path.join(repoStateDir, fileName),
+        [
+          `# ${fileName.replace(/\.md$/, "").replace(/_/g, " ")}`,
+          "",
+          "OpenReactor builds and operates this product through GitHub issues, Codex agents, and repo-local product steering.",
+          "",
+          "This document is intentionally specific enough for implementation agents to use without relying on bootstrap placeholder text."
+        ].join("\n") + "\n",
+        "utf8"
+      );
+    }
+
+    const readiness = await checkRepoStateReadiness(repoRoot);
+
+    expect(readiness.ready).toBe(true);
+    expect(readiness.missing).toEqual([]);
+    expect(readiness.placeholders).toEqual([]);
+  });
+});
+
+function createTempRepoRoot(): string {
+  const repoRoot = path.join(
+    os.tmpdir(),
+    `openreactor-repo-state-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  );
+  tempDirs.push(repoRoot);
+  return repoRoot;
+}

--- a/tests/workspace-policy.spec.ts
+++ b/tests/workspace-policy.spec.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
-import { resolveWorkspacePolicy } from "../reactor/workspace-policy";
+import { resolveWorkspacePolicy, runWorkspacePolicyCommand } from "../reactor/workspace-policy";
 
 const tempDirs: string[] = [];
 
@@ -59,6 +59,30 @@ describe("workspace policy", () => {
         FOO: "bar"
       }
     });
+  });
+
+  test("runs provision command with policy environment", async () => {
+    const repoRoot = createTempRepoRoot();
+    const runDir = path.join(repoRoot, ".openreactor", "runs", "issue-7");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await fs.mkdir(runDir, { recursive: true });
+
+    const result = await runWorkspacePolicyCommand({
+      command:
+        'printf "%s:%s:%s" "$OPENREACTOR_WORKSPACE_PHASE" "$CUSTOM_VALUE" "$OPENREACTOR_BRANCH_NAME"',
+      cwd: repoRoot,
+      env: {
+        CUSTOM_VALUE: "from-policy"
+      },
+      phase: "provision",
+      policyPath: path.join(repoRoot, "workspace-policy.json"),
+      issueNumber: 7,
+      branchName: "openreactor/issue-7",
+      runDir
+    });
+
+    expect(result.stdout).toBe("provision:from-policy:openreactor/issue-7");
+    expect(result.stderr).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary
- add the Project Genesis output contract and stack-specific workflow guidance
- route frontend/design work to a Codex UI agent with an xhigh design-image prepass
- add Genesis readiness checks, workspace provision startup hooks, and matching docs/prompts/tests

## Notes
- The UI design prepass intentionally keeps the same full-access Codex execution mode as implementation runs.

## Tests
- bun run check
- bun test
- bun run test:ui
- bun run reactor:tool check-genesis